### PR TITLE
fix fragile csv finding in KPM/OCRB viewss

### DIFF
--- a/budget_proj/budget_app/views.py
+++ b/budget_proj/budget_app/views.py
@@ -65,7 +65,7 @@ def find_kpm_data():
 class ListOcrb(generics.ListAPIView):
     """
     A class based view that inherits from the generics class. The generics
-    class gives you a convinient way to declare views quickly when you only
+    class gives you a convenient way to declare views quickly when you only
     need basic functionality or simple CRUD operations.
     """
     queryset = find_ocrb_data()
@@ -74,7 +74,7 @@ class ListOcrb(generics.ListAPIView):
 
 class ListKpm(generics.ListAPIView):
     """
-    A class based view that inherits from the movies class
+    A class based view that inherits from the generics class as well.
     """
     queryset = find_kpm_data()
     serializer_class = serializers.KpmSerializer

--- a/budget_proj/budget_app/views.py
+++ b/budget_proj/budget_app/views.py
@@ -1,4 +1,5 @@
-import csv
+import csv, os
+from django.conf import settings
 
 # ------------------------------------------
 # imports needed for the functional view
@@ -22,7 +23,7 @@ from . import serializers
 # def ocrb(request):
 #     """
 #     A function based view that uses the api_view decorator to add functionality
-#     to the view.   
+#     to the view.
 #     """
 #     if request.method == 'GET':
 #         ocrb_all_bureaus = models.Ocrb.objects.all()
@@ -30,51 +31,50 @@ from . import serializers
 #         return Response(serializer.data)
 
 
+def find_ocrb_data():
+    """
+    helper method to read and parse ocrb csv data.
+    To be used until we get data loaded into our models
+    """
+    fname = 'Budget_in_Brief_OCRB_data_All_Years.csv'
+    f = open(os.path.join(settings.BASE_DATA_DIR, fname), 'r')
+    col_headers = ['source_document', 'service_area', 'bureau', 'budget_category', 'amount', 'fy', 'budget_type']
+    reader = csv.DictReader(f, col_headers)
+    next(reader) # skip column headers
+    all_objects = [models.OCRB(**row) for row in reader]
+    return all_objects
+
+
+def find_kpm_data():
+    """
+    helper method to read and parse kpm csv data.
+    To be used until we get data loaded into our models
+    """
+    fname = 'Budget_in _Brief_KPM_data_All_Years.csv'
+    f = open(os.path.join(settings.BASE_DATA_DIR, fname), 'r')
+    col_headers = ['source_document', 'service_area', 'bureau', 'key_performance_measures', 'fy', 'budget_type', 'amount',
+        'units']
+    reader = csv.DictReader(f, col_headers)
+    next(reader) # skip column headers
+    all_objects = [models.KPM(**row) for row in reader]
+    for obj in all_objects: # remove empty strings from number fields, fix in serializer?
+        if obj.amount == '':
+            obj.amount = None
+    return all_objects
+
 class ListOcrb(generics.ListAPIView):
     """
     A class based view that inherits from the generics class. The generics
     class gives you a convinient way to declare views quickly when you only
     need basic functionality or simple CRUD operations.
     """
-    queryset = models.OCRB.objects.all()
+    queryset = find_ocrb_data()
     serializer_class = serializers.OcrbSerializer
-
-
-    def get(self, request, format=None):
-        f = '../Data/Budget_in_Brief_OCRB_data_All_Years.csv'
-        col_headers = ['source_document', 'service_area', 'bureau', 'budget_category', 'amount', 'fy', 'budget_type']
-        reader = csv.DictReader(open(f, 'r'), col_headers)
-        all_data = [obj for obj in reader]
-
-        # skip header row
-        all_data = all_data[1:]
-        all_obj = [models.OCRB(**data) for data in all_data]
-        serializer = serializers.OcrbSerializer(all_obj, many=True)
-
-        return Response(serializer.data)
 
 
 class ListKpm(generics.ListAPIView):
     """
     A class based view that inherits from the movies class
     """
-    queryset = models.KPM.objects.all()
+    queryset = find_kpm_data()
     serializer_class = serializers.KpmSerializer
-
-    def get(self, request, format=None):
-        f = '../Data/Budget_in _Brief_KPM_data_All_Years.csv'
-        col_headers = ['source_document', 'service_area', 'bureau', 'key_performance_measures', 'fy', 'budget_type', 'amount',
-        'units']
-        reader = csv.DictReader(open(f, 'r'), col_headers)
-        all_data = [obj for obj in reader]
-
-        # skip header row
-        all_data = all_data[1:]
-        all_obj = [models.KPM(**data) for data in all_data]
-        for obj in all_obj: # remove empty strings from number fields
-            if obj.amount == '':
-                obj.amount = None
-
-        serializer = serializers.KpmSerializer(all_obj, many=True)
-
-        return Response(serializer.data)

--- a/budget_proj/budget_proj/settings.py
+++ b/budget_proj/budget_proj/settings.py
@@ -15,6 +15,9 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+# Set directory that contains our csv data etc.
+BASE_DATA_DIR = os.path.join(os.path.dirname(BASE_DIR), 'Data')
+
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
@@ -38,7 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     # *******************************
-    # added outside of default setup 
+    # added outside of default setup
     'rest_framework',
     'budget_app',
     # *******************************


### PR DESCRIPTION
closes #23 

Added another constant to the django settings with proper location of the data directory.  Access it with `from django.conf import settings     settings.BASE_DATA_DIR`

Also moved the csv parsing logic into their own functions, so we can use the generics.Listview interface the same way we will when we get data in the db.