### PR TITLE
Implemented 'summary' endpoint that filters on query parameter values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ http://127.0.0.1:8000/budget
 # To get the 'Adopted' budget information for all bureaus in the 
 # 'City Support Services' service area for fiscal year '2015-16':
 http://127.0.0.1:8000/budget?fy=2015-16&service_area=City Support Services&budget_type=Adopted
-# To get all budget_type information for the 'Bureau of Fire & Police Disability & Retirement'
+# To get all budget_type information for the 'Portland Bureau of Emergency Management'
 # for all years of available data.
 http://127.0.0.1:8000/budget?bureau=Portland Bureau of Emergency Management
 # To get all budget_type information for the 'Bureau of Fire & Police Disability & Retirement'

--- a/README.md
+++ b/README.md
@@ -18,14 +18,44 @@ virtualenv -p python3 budget_venv
 source budget_venv/bin/activate
 pip install -r requirements.txt
 ```
+
 Run the app server:
 ```
 python3 budget_proj/manage.py runserver
 ```
-Then launch your browser and browse to one of these two endpoints (not currently pulling data):
+
+Import data into the database. From the top level directory, run the following script to 
+load the Operating and Capital Requirements by Bureau (OCRB) data.
+```
+./budget_proj/manage.py importcsv budget_app.OCRB ./Data/Budget_in_Brief_OCRB_data_All_Years.csv "Source document:source_document" "Service Area:service_area" "Bureau:bureau" "Budget Category:budget_category" "Amount:amount" "FY:fy" "Budget Type:budget_type"
+```
+
+Then launch your browser and browse to one of several endpoints:<br>
+(1) Download all OCRB data. No query parameters are accepted.
+```
 http://127.0.0.1:8000/ocrb
+```
+
+(2) Use query parameters to select a subset of the budget data.
+```
+http://127.0.0.1:8000/budget
+# To get the 'Adopted' budget information for all bureaus in the 
+# 'City Support Services' service area for fiscal year '2015-16':
+http://127.0.0.1:8000/budget?fy=2015-16&service_area=City Support Services&budget_type=Adopted
+# To get all budget_type information for the 'Bureau of Fire & Police Disability & Retirement'
+# for all years of available data.
+http://127.0.0.1:8000/budget?bureau=Portland Bureau of Emergency Management
+# To get all budget_type information for the 'Bureau of Fire & Police Disability & Retirement'
+# for all years of available data. Note that '&' embedded in the name must be URI encoded to '%26':
+http://127.0.0.1:8000/budget?bureau=Bureau of Fire %26 Police Disability %26 Retirement
+```
+
+(3) Download all Key Performance Measure (KPM) data.
+```
 http://127.0.0.1:8000/kpm
+```
 
 # Endpoint map
-- OCRB: provides data from City of Portland Budget in Brief documents (e.g. FY 2016-17), all Service Area sections, table "Operating and Capital Requirements by Bureau"
-- KPM: provides data from City of Portland Budget in Brief documents (e.g. FY 2016-17), all Service Area sections, table "Key Performance Measures"
+- ocrb: provides data from City of Portland Budget in Brief documents (e.g. FY 2016-17), all Service Area sections, table "Operating and Capital Requirements by Bureau".
+- budget: uses query parameters to return subsets of the budget data given by the 'ocrb' endpoint.
+- kpm: provides data from City of Portland Budget in Brief documents (e.g. FY 2016-17), all Service Area sections, table "Key Performance Measures".

--- a/README.md
+++ b/README.md
@@ -19,13 +19,18 @@ source budget_venv/bin/activate
 pip install -r requirements.txt
 ```
 
+Run the migrate scripts:
+```
+python3 budget_proj/manage.py migrate
+```
+
 Run the app server:
 ```
 python3 budget_proj/manage.py runserver
 ```
 
 Import data into the database. From the top level directory, run the following script to 
-load the Operating and Capital Requirements by Bureau (OCRB) data.
+load the Operating and Capital Requirements by Bureau (OCRB) data into the embedded sqlite3 database:
 ```
 ./budget_proj/manage.py importcsv budget_app.OCRB ./Data/Budget_in_Brief_OCRB_data_All_Years.csv "Source document:source_document" "Service Area:service_area" "Bureau:bureau" "Budget Category:budget_category" "Amount:amount" "FY:fy" "Budget Type:budget_type"
 ```
@@ -52,7 +57,7 @@ http://127.0.0.1:8000/summary?bureau=Bureau of Fire %26 Police Disability %26 Re
 ```
 
 The sort order returned by /summary is always the same, i.e. you are not allowed to pass parameters
-to change the sort order, although that could be an enhancement in the future.
+to change the sort order. However, that could be an enhancement in the future.
 
 (3) Download all Key Performance Measure (KPM) data.
 ```
@@ -61,5 +66,5 @@ http://127.0.0.1:8000/kpm
 
 # Endpoint map
 - ocrb: provides data from City of Portland Budget in Brief documents (e.g. FY 2016-17), all Service Area sections, table "Operating and Capital Requirements by Bureau".
-- budget: uses query parameters to return subsets of the budget data given by the 'ocrb' endpoint.
+- summary: uses query parameters to return subsets of the budget data given by the 'ocrb' endpoint.
 - kpm: provides data from City of Portland Budget in Brief documents (e.g. FY 2016-17), all Service Area sections, table "Key Performance Measures".

--- a/README.md
+++ b/README.md
@@ -36,19 +36,23 @@ Then launch your browser and browse to one of several endpoints:<br>
 http://127.0.0.1:8000/ocrb
 ```
 
-(2) Use query parameters to select a subset of the budget data.
+(2) Use query parameters to select a subset of the budget data summarized by bureau.
 ```
-http://127.0.0.1:8000/budget
+# To get all summary data, which is the same as for the /ocrb endpoint, except that /summary sorts the data:
+http://127.0.0.1:8000/summary
 # To get the 'Adopted' budget information for all bureaus in the 
 # 'City Support Services' service area for fiscal year '2015-16':
-http://127.0.0.1:8000/budget?fy=2015-16&service_area=City Support Services&budget_type=Adopted
-# To get all budget_type information for the 'Portland Bureau of Emergency Management'
+http://127.0.0.1:8000/summary?fy=2015-16&service_area=City Support Services&budget_type=Adopted
+# To get all summary information for the 'Portland Bureau of Emergency Management'
 # for all years of available data.
-http://127.0.0.1:8000/budget?bureau=Portland Bureau of Emergency Management
-# To get all budget_type information for the 'Bureau of Fire & Police Disability & Retirement'
+http://127.0.0.1:8000/summary?bureau=Portland Bureau of Emergency Management
+# To get all summary information for the 'Bureau of Fire & Police Disability & Retirement'
 # for all years of available data. Note that '&' embedded in the name must be URI encoded to '%26':
-http://127.0.0.1:8000/budget?bureau=Bureau of Fire %26 Police Disability %26 Retirement
+http://127.0.0.1:8000/summary?bureau=Bureau of Fire %26 Police Disability %26 Retirement
 ```
+
+The sort order returned by /summary is always the same, i.e. you are not allowed to pass parameters
+to change the sort order, although that could be an enhancement in the future.
 
 (3) Download all Key Performance Measure (KPM) data.
 ```

--- a/budget_proj/budget_app/models.py
+++ b/budget_proj/budget_app/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+
 class OCRB(models.Model):
     id = models.AutoField(primary_key=True)
     source_document = models.CharField(max_length=255, default='')
@@ -9,7 +10,6 @@ class OCRB(models.Model):
     amount = models.IntegerField(blank=True, null=True)
     fy = models.CharField(max_length=255, default='')
     budget_type = models.CharField(max_length=255, default='')
-
 
 
 class KPM(models.Model):

--- a/budget_proj/budget_app/serializers.py
+++ b/budget_proj/budget_app/serializers.py
@@ -7,6 +7,7 @@ class OcrbSerializer(serializers.ModelSerializer):
         model = models.OCRB
         exclude = ('id',)
 
+
 class KpmSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.KPM

--- a/budget_proj/budget_app/urls.py
+++ b/budget_proj/budget_app/urls.py
@@ -2,8 +2,9 @@ from django.conf.urls import url
 from . import views
 
 
+# Listed in alphabetical order.
 urlpatterns = [
-    url(r'^ocrb/$', views.ListOcrb.as_view()),
     url(r'^kpm/$', views.ListKpm.as_view()),
-    url(r'^budget/', views.FindOperatingAndCapitalRequirements.as_view()),
+    url(r'^ocrb/$', views.ListOcrb.as_view()),
+    url(r'^summary/', views.FindOperatingAndCapitalRequirements.as_view()),
 ]

--- a/budget_proj/budget_app/urls.py
+++ b/budget_proj/budget_app/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     url(r'^ocrb/$', views.ListOcrb.as_view()),
     url(r'^kpm/$', views.ListKpm.as_view()),
+    url(r'^budget/', views.FindOperatingAndCapitalRequirements.as_view()),
 ]

--- a/budget_proj/budget_app/views.py
+++ b/budget_proj/budget_app/views.py
@@ -71,11 +71,22 @@ class ListKpm(generics.ListAPIView):
 
 class FindOperatingAndCapitalRequirements(generics.ListAPIView):
     """
-    Uses query parameters to select items to be returned.
-    Assumption: the Model gets data from the database.
-    This enables us to use Model attributes, like 'objects',
-    and a QuerySet, which enables use of 'filter' and 'order_by'.
+    Uses query parameters to select items to be returned from the database that summarizes Operating and Capital Requirements by Bureau.
+
+    No more than one instance of each parameter may be given. For example,
+      To see all records for all service areas:
+        /summary
+      To see only records for bureaus in the 'Community Development' service_area:
+        /summary?service_area=Community Development
+      To see only records for fiscal year '2015-16' for the bureaus in the 'Community Development' service_area:
+        /summary?fy=2015-16&service_area=Community Development
+      To see only 'Adopted' budget figures for the 'Portland Parks & Recreation' bureau (Note: the '&' embedded in the bureau name must be URI encoded as '%26'):
+        /summary?budget_type=Adopted&bureau=Portland Parks %26 Recreation
     """
+    # Assumption: the Model gets data from the database.
+    # This enables us to use Model attributes, like 'objects',
+    # and a QuerySet, which enables use of 'filter' and 'order_by'.
+
     serializer_class = serializers.OcrbSerializer
 
     def get_queryset(self):

--- a/budget_proj/budget_app/views.py
+++ b/budget_proj/budget_app/views.py
@@ -82,6 +82,10 @@ class FindOperatingAndCapitalRequirements(generics.ListAPIView):
         /summary?fy=2015-16&service_area=Community Development
       To see only 'Adopted' budget figures for the 'Portland Parks & Recreation' bureau (Note: the '&' embedded in the bureau name must be URI encoded as '%26'):
         /summary?budget_type=Adopted&bureau=Portland Parks %26 Recreation
+      If there are no matches for the query parameters, an empty list is returned:
+        /summary?fy=1776-77
+      which usually means that you spelled one of the parameter names wrong or you gave an unknown value for the parameter. However, the service still returns an HTTP 200 OK response, because an empty list is a valid response.
+      Note: Parameter names and parameter values are not case-sensitive.
     """
     # Assumption: the Model gets data from the database.
     # This enables us to use Model attributes, like 'objects',
@@ -100,17 +104,17 @@ class FindOperatingAndCapitalRequirements(generics.ListAPIView):
         queryset = models.OCRB.objects.all()
         fiscal_year = self.request.query_params.get('fy', None)
         if fiscal_year is not None:
-            queryset = queryset.filter(fy__exact=fiscal_year)
+            queryset = queryset.filter(fy__iexact=fiscal_year)
         service_area = self.request.query_params.get('service_area', None)
         if service_area is not None:
-            queryset = queryset.filter(service_area__exact=service_area)
+            queryset = queryset.filter(service_area__iexact=service_area)
         bureau = self.request.query_params.get('bureau', None)
         if bureau is not None:
-            queryset = queryset.filter(bureau__exact=bureau)
+            queryset = queryset.filter(bureau__iexact=bureau)
         budget_type = self.request.query_params.get('budget_type', None)
         if budget_type is not None:
-            queryset = queryset.filter(budget_type__exact=budget_type)
+            queryset = queryset.filter(budget_type__iexact=budget_type)
         budget_category = self.request.query_params.get('budget_category', None)
         if budget_category is not None:
-            queryset = queryset.filter(budget_category__exact=budget_category)
+            queryset = queryset.filter(budget_category__iexact=budget_category)
         return queryset.order_by('fy', 'budget_type', 'service_area', 'bureau', 'budget_category')


### PR DESCRIPTION
I did this work, because it seems like the implementation of `OCRB` and `KPM` endpoints is working around Django, rather than using key elements of the framework. I wanted to use `filter` and `order_by` on the `all_obj` object (prior to pull request #25), but I could not see how to do that. I also wanted the Models to be attached to the database. So I implemented a `summary` endpoint that assumes data has been loaded into the database, e.g. using Aaron's `importcsv` utility. See the `README` file for how to load the database. The implementation demonstrates an API that uses query parameters for filtering the values returned by the web service. I would like to add Swagger annotations to document the options, but for now I provided a few sample queries in the view documentation, which Django renders when a GET is submitted from a browser.

I also deleted unused variables and old code that was previously commented out and no longer used.