### PR TITLE
Fixed 'Double requirement given' error on pip install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ source budget_venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Run the migrate scripts:
+If you are configured to use a local database for development, you might need to run the migrate scripts. You only need to run this when the models have changed:
 ```
+python3 budget_proj/manage.py makemigrations
 python3 budget_proj/manage.py migrate
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,3 @@ requests==2.13.0
 six==1.10.0
 
 gunicorn
-django-rest-swagger
-psycopg2


### PR DESCRIPTION
I removed redundant lines from 'requirements.txt', which were causing an error:
```
$ pip install -r requirements.txt
Double requirement given: django-rest-swagger (from -r requirements.txt (line 13)) (already in django-rest-swagger==2.1.1 (from -r requirements.txt (line 4)), name='django-rest-swagger')
```

I also added to README.md about when to run the migrate.