### PR TITLE
Specified a license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Hack Oregon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Per the current recommended approach for organizing code in repos, Budget team w
 - team-budget: repo for all code related to backend (Django, API) and data/database
 - team-budget-frontend: repo for all code related to frontend (React/HTML/CSS/JS)
 
-# Setting up local development
+## Setting up local development
 
 Clone, configure your virtual environment and install requirements:
 ```
@@ -70,7 +70,10 @@ to change the sort order. However, that could be an enhancement in the future.
 http://127.0.0.1:8000/kpm
 ```
 
-# Endpoint map
+## Endpoint map
 - ocrb: provides data from City of Portland Budget in Brief documents (e.g. FY 2016-17), all Service Area sections, table "Operating and Capital Requirements by Bureau".
 - summary: uses query parameters to return subsets of the budget data given by the 'ocrb' endpoint.
 - kpm: provides data from City of Portland Budget in Brief documents (e.g. FY 2016-17), all Service Area sections, table "Key Performance Measures".
+
+## License
+This project is licensed under the terms of the MIT license.


### PR DESCRIPTION
Added a license, so that it is clear under what conditions Hack Oregon allows others to use their software. Specifying a license is recommended by GitHub and many other people and organizations.