### PR TITLE
Please add this 192 address for the forseeable future to troubleshoot Docker builds

### DIFF
--- a/budget_proj/budget_proj/settings.py
+++ b/budget_proj/budget_proj/settings.py
@@ -29,10 +29,8 @@ SECRET_KEY = project_config.DJANGO_SECRET
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-# 2017-02-23: This was necessary to workaround DISALLOWED_HOSTS errors for
-# both Docker Toolkit and native Docker testing
-#ALLOWED_HOSTS = ['192.168.99.100', 'localhost', '127.0.0.1']
-ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '.elb.amazonaws.com']
+# The 192. address is necessary to enable testing with Docker Toolbox for Mac and Windows
+ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '.elb.amazonaws.com', '192.168.99.100']
 
 # Get the IPV4 address we're working with on AWS
 # The Loadbalancer uses this ip address for healthchecks


### PR DESCRIPTION
I need to add this IP address to ALLOWED_HOSTS to be able to troubleshoot Docker builds.

It harms nothing for any staging, integration or production release as it's a non-routable address that will never be used in any of the Virtual Private Cloud configurations we plan to enable in AWS.

If you like, we can file an issue in this repo to remove this address from `settings.py` in the future.