### PR TITLE
Docker container successfully built locally and under Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ sudo: required
 services:
   - docker
 script:
-  - ./bin/build-proj.sh
+  - ./budget_proj/bin/build-proj.sh
 after_success:
-  - ./bin/docker-push.sh
+  - ./budget_proj/bin/docker-push.sh

--- a/budget_proj/bin/build-proj.sh
+++ b/budget_proj/bin/build-proj.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-docker-compose build
+docker-compose -f budget_proj/docker-compose.yml build


### PR DESCRIPTION
In an alternate universe yesterday (#53 & #54), I was able to get Travis to successfully build a Docker container with our current Django API endpoints.  However, that universe collapsed after I continued to play with the laws of physics (kept committing changes before I realized I hadn't created a separate branch).  I finally abandoned that effort and started over today from `master`.

This PR is the smallest successful demonstration of Docker building the container via Travis:
https://travis-ci.org/hackoregon/team-budget/builds/209881091

It should also build successfully from your local machine.  [I swear I tested this three ways today before committing the PR.  I'm praying to the lords of the bitstream this works today.]

# How to Test

- `git checkout docker_and_travis`
- `./budget_proj/bin/build-proj.sh`

## Expected result: 
The build should end with results similar to the following (but with a different container ID than **f6eb143e7bc3**):

```
Step 12/12 : WORKDIR /code
 ---> f6eb143e7bc3
Removing intermediate container b788cb2b59e0
Successfully built f6eb143e7bc3
```