### PR TITLE
suppressing warnings to enable travis to successfully build a PR

### DIFF
--- a/budget_proj/bin/test-proj.sh
+++ b/budget_proj/bin/test-proj.sh
@@ -6,4 +6,4 @@
 echo  Running test_proj.sh...
 
 # Run all configured unit tests inside the Docker container
-docker-compose -f budget_proj/docker-compose.yml run budget-service python manage.py test
+docker-compose -f budget_proj/docker-compose.yml run budget-service python manage.py test --no-input


### PR DESCRIPTION
# Problem Statement

For all PRs submitted to this project, there are two Travis builds that are kicked off:
- continuous-integration/travis-ci/pr
- continuous-integration/travis-ci/push

The `pr` build always fails, and the `push` build usually passes.

The tail end of the Travis build log for the `pr` build always ends with these messages:

```
Step 12 : WORKDIR /code
 ---> Running in 28c1d878ad69
 ---> 1323f3a5a0b5
Removing intermediate container 28c1d878ad69
Successfully built 1323f3a5a0b5
WARNING: Image for service budget-service was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating test database for alias 'default'...
Got an error creating the test database: database "test_budget" already exists
Type 'yes' if you would like to try deleting the test database 'test_budget', or 'no' to cancel: 
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated
```

# Proposed Solution

According to [Django docs](https://docs.djangoproject.com/en/1.10/ref/django-admin/#test), this warning can be suppressed using the `--noinput` (or better, the new alias `--no-input`) parameter.

The intent of this PR is to suppress the warning, such that the "existing" test database gets automatically deleted, SO THAT THE BUILD COMPLETES AND PASSES.

# How to Test

Examine the status of the "**continuous-integration/travis-ci/pr**" above the "**Merge pull request**" button in this page.  If it reports "The Travis CI build passed" then we're good to go.