### PR TITLE
[tech debt] Cleaning up the Dockerfile

### DIFF
--- a/budget_proj/Dockerfile
+++ b/budget_proj/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.5
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code

--- a/budget_proj/Dockerfile
+++ b/budget_proj/Dockerfile
@@ -5,12 +5,3 @@ WORKDIR /code
 ADD requirements.txt /code/
 RUN pip install -r requirements.txt
 ADD . /code/
-RUN mkdir /Data
-WORKDIR /Data
-RUN wget \
-    -O /Data/Budget_in_Brief_KPM_data_All_Years.csv \
-    https://raw.githubusercontent.com/hackoregon/team-budget/master/Data/Budget_in_Brief_KPM_data_All_Years.csv
-RUN wget \
-    -O /Data/Budget_in_Brief_OCRB_data_All_Years.csv \
-    https://raw.githubusercontent.com/hackoregon/team-budget/master/Data/Budget_in_Brief_OCRB_data_All_Years.csv
-WORKDIR /code

--- a/budget_proj/Dockerfile
+++ b/budget_proj/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.5
 ENV PYTHONUNBUFFERED 1
-RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code/
 RUN pip install -r requirements.txt


### PR DESCRIPTION
On the basis of PR #74, I'm now ready to cleanup tech debt in the build process and rely on the Travis build status to confirm I haven't broken anything (via the basic functional tests).

This cleanup removes three things:
1. The now-redundant download of CSV data to the Docker image.  @mxmoss confirmed for me (again, due to my poor memory) that as of a week ago, the Django APIs were all relying on the external database rather than imported CSVs to construct their data responses.
2. The unreliable `python:latest` image, that @tedbrunner was unable to download when building the Docker container locally [while testing PR #74] on his Linux computer - he received an error "UNAUTHORIZED - authentication required" at step 1 of the docker container build, which corresponds to the error I see when I browse to the [URL specified in the error output](https://registry-1.docker.io/v2/library/python/manifests/latest).
3. Also, trivially it is unnecessary to instruct Docker to `RUN mkdir /code` when the next statement is `WORKDIR /code` - according to [Docker docs](https://docs.docker.com/engine/reference/builder/#workdir), the **WORKDIR** instruction will always create the target directory if it doesn't already exist.