### PR TITLE
[Tech debt] Clean up the install of the AWS CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 services:
   - docker
 install:
-  - pip install awscli
+  - pip install --upgrade --user awscli
 before_script:
   - ./budget_proj/bin/getconfig.sh
 script:

--- a/budget_proj/bin/docker-entrypoint.sh
+++ b/budget_proj/bin/docker-entrypoint.sh
@@ -2,7 +2,6 @@
 
 echo  Running docker-entrypoint.sh...
 
-#export PATH=$PATH:~/.local/bin # necessary to help locate the awscli binaries which are pip installed --user
 #./bin/getconfig.sh
 #python manage.py migrate --no-input
 #python manage.py collectstatic --no-input

--- a/budget_proj/bin/docker-entrypoint.sh
+++ b/budget_proj/bin/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 echo  Running docker-entrypoint.sh...
 
-export PATH=$PATH:~/.local/bin # necessary to help locate the awscli binaries which are pip installed --user
+#export PATH=$PATH:~/.local/bin # necessary to help locate the awscli binaries which are pip installed --user
 #./bin/getconfig.sh
 #python manage.py migrate --no-input
 #python manage.py collectstatic --no-input

--- a/budget_proj/bin/docker-entrypoint.sh
+++ b/budget_proj/bin/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 echo  Running docker-entrypoint.sh...
 
-export PATH=$PATH:~/.local/bin
+export PATH=$PATH:~/.local/bin # necessary to help locate the awscli binaries which are pip installed --user
 #./bin/getconfig.sh
 #python manage.py migrate --no-input
 #python manage.py collectstatic --no-input

--- a/budget_proj/bin/getconfig.sh
+++ b/budget_proj/bin/getconfig.sh
@@ -21,7 +21,7 @@ else
     echo -e  "USING $DEPLOY_TARGET CONFIG"
     echo -e  "USING THE $CONFIG_BUCKET CONFIG BUCKET"
     echo -e "########################################"
-    export PATH=$PATH:~/.local/bin # TODO is this necessary for anything?
+    export PATH=$PATH:~/.local/bin # necessary to help locate the awscli binaries which are pip installed --user
     aws s3 cp \
           s3://$CONFIG_BUCKET/$DEPLOY_TARGET/$CONFIG_FILE \
           $PROJ_SETTINGS_DIR/budget_proj/$CONFIG_FILE;

--- a/budget_proj/bin/test-entrypoint.sh
+++ b/budget_proj/bin/test-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-./bin/getconfig.sh
+export PATH=$PATH:~/.local/bin
+#./bin/getconfig.sh
 #python manage.py migrate --noinput
 python manage.py test --no-input

--- a/budget_proj/bin/test-entrypoint.sh
+++ b/budget_proj/bin/test-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export PATH=$PATH:~/.local/bin
+export PATH=$PATH:~/.local/bin # necessary to help locate the awscli binaries which are pip installed --user
 ./bin/getconfig.sh
 #python manage.py migrate --noinput
 python manage.py test --no-input

--- a/budget_proj/bin/test-entrypoint.sh
+++ b/budget_proj/bin/test-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export PATH=$PATH:~/.local/bin # necessary to help locate the awscli binaries which are pip installed --user
+#export PATH=$PATH:~/.local/bin # necessary to help locate the awscli binaries which are pip installed --user
 ./bin/getconfig.sh
 #python manage.py migrate --noinput
 python manage.py test --no-input

--- a/budget_proj/bin/test-entrypoint.sh
+++ b/budget_proj/bin/test-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#export PATH=$PATH:~/.local/bin # necessary to help locate the awscli binaries which are pip installed --user
 ./bin/getconfig.sh
 #python manage.py migrate --noinput
 python manage.py test --no-input


### PR DESCRIPTION
Clean up unnecessary (and confusing, for other DevOps engineers at least) PATH statements in the build.  May have to add some back if there are other tools installed as a result of enabling CD (continuous deployment).

While I'm at it, finally understood whether to use the command line parameters for installing the awscli - in a word, yes - at least [according to the AWS CLI docs](http://docs.aws.amazon.com/cli/latest/userguide/installing.html).