### PR TITLE
Removing test-entrypoint.sh [not needed]

### DIFF
--- a/budget_proj/bin/test-entrypoint.sh
+++ b/budget_proj/bin/test-entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-export PATH=$PATH:~/.local/bin
-./bin/getconfig.sh
-#python manage.py migrate --noinput
-python manage.py test --no-input


### PR DESCRIPTION
Removing the whole file where a redundant call is made to `getconfig.sh` - turns out this script is no longer being used anywhere in this project.

I've tested this both locally and via Travis, and both still build and test fine without this script.