### PR TITLE
Usage message proactive prompt

### DIFF
--- a/budget_proj/bin/build-proj.sh
+++ b/budget_proj/bin/build-proj.sh
@@ -2,6 +2,8 @@
 
 usage() { echo "Usage: $0 [-l] for a local build or [-t] for a travis build " 1>&2; exit 1; }
 
+if [ $# == 0 ]; then usage; fi
+
 echo  Running build-proj.sh...
 
 while getopts ":lt" opt; do

--- a/budget_proj/bin/start-proj.sh
+++ b/budget_proj/bin/start-proj.sh
@@ -2,6 +2,8 @@
 
 usage() { echo "Usage: $0 [-l] for a local build or [-t] for a travis build " 1>&2; exit 1; }
 
+if [ $# == 0 ]; then usage; fi
+
 # PURPOSE: used to launch the Django app inside the Docker container
 # Can be used on local developer machine; if used in Travis build, will fail the build after 10min timeout
 

--- a/budget_proj/bin/test-proj.sh
+++ b/budget_proj/bin/test-proj.sh
@@ -4,6 +4,8 @@
 
 usage() { echo "Usage: $0 [-l] for a local test or [-t] for a travis test " 1>&2; exit 1; }
 
+if [ $# == 0 ]; then usage; fi
+
 echo  Running test_proj.sh...
 
 # Run all configured unit tests inside the Docker container

--- a/budget_proj/budget_proj/project_config_template.py
+++ b/budget_proj/budget_proj/project_config_template.py
@@ -10,7 +10,7 @@ AWS = {
     'USER': 'PUT_DATABASE_LOGIN_ID_HERE',
     'PASSWORD': 'PUT_DATABASE_PASSWORD_HERE'
 }
-DJANGO_SECRET = 'PUT_DJANGO_SECRET_HERE'
+DJANGO_SECRET_KEY = 'PUT_DJANGO_SECRET_HERE'
 
 # Note: the 192.168.99.100 address is necessary to enable testing with Docker Toolbox for Mac and Windows
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '192.168.99.100']


### PR DESCRIPTION
The current scripts just give the user a blank response if they don't include the `-l` or `-t` required parameter.

This enhancement enables the user to know what to do if they've forgotten the parameter.

# How to Test
- `git pull`
- `git checkout usage-prompts`
- `./budget_proj/bin/test-proj.sh`

Expected response: nothing appears to happen.

Then try running `./budget_proj/bin/test-proj.sh -l` and you'll see the Docker build and tests run.