### PR TITLE
Enable Deployment to AWS ECS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_script:
 script:
   - './budget_proj/bin/test-proj.sh -t'
 after_success:
-#  - ./budget_proj/bin/docker-push.sh
+  - ./budget_proj/bin/docker-push.sh

--- a/budget_proj/Dockerfile
+++ b/budget_proj/Dockerfile
@@ -14,3 +14,4 @@ RUN wget \
     -O /Data/Budget_in_Brief_OCRB_data_All_Years.csv \
     https://raw.githubusercontent.com/hackoregon/team-budget/master/Data/Budget_in_Brief_OCRB_data_All_Years.csv
 WORKDIR /code
+ENTRYPOINT [ "/code/bin/docker-entrypoint.sh" ]

--- a/budget_proj/bin/docker-push.sh
+++ b/budget_proj/bin/docker-push.sh
@@ -3,7 +3,7 @@
 # Tag, Push and Deploy only if it's not a pull request
 if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   # Push only if we're testing the master branch
-  if [ "$TRAVIS_BRANCH" == "master" ]; then
+#  if [ "$TRAVIS_BRANCH" == "master" ]; then
     pip install --user awscli
     export PATH=$PATH:$HOME/.local/bin
     docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" "$DOCKER_REPO"
@@ -12,9 +12,9 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
      -n "$ECS_SERVICE_NAME" \
      -c "$ECS_CLUSTER"   \
      -i "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest
-   else
-     echo "Skipping deploy because branch is not master"
-  fi
+#   else
+#     echo "Skipping deploy because branch is not master"
+#  fi
 else
   echo "Skipping deploy because it's a pull request"
 fi

--- a/budget_proj/bin/docker-push.sh
+++ b/budget_proj/bin/docker-push.sh
@@ -3,7 +3,7 @@
 # Tag, Push and Deploy only if it's not a pull request
 if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   # Push only if we're testing the master branch
-#  if [ "$TRAVIS_BRANCH" == "master" ]; then
+  if [ "$TRAVIS_BRANCH" == "master" ]; then
     export PATH=$PATH:$HOME/.local/bin
     echo Getting the ECR login... # Troubleshooting
     eval $(aws ecr get-login --region $AWS_DEFAULT_REGION)
@@ -14,9 +14,9 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
      -n "$ECS_SERVICE_NAME" \
      -c "$ECS_CLUSTER"   \
      -i "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest
-#   else
-#     echo "Skipping deploy because branch is not master"
-#  fi
+   else
+     echo "Skipping deploy because branch is not master"
+  fi
 else
   echo "Skipping deploy because it's a pull request"
 fi

--- a/budget_proj/bin/docker-push.sh
+++ b/budget_proj/bin/docker-push.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+# Tag, Push and Deploy only if it's not a pull request
+if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  # Push only if we're testing the master branch
+  if [ "$TRAVIS_BRANCH" == "master" ]; then
+    pip install --user awscli
+    export PATH=$PATH:$HOME/.local/bin
+    docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" "$DOCKER_REPO"
+    docker push "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest
+    ./bin/ecs-deploy.sh  \
+     -n "$ECS_SERVICE_NAME" \
+     -c "$ECS_CLUSTER"   \
+     -i "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest
+   else
+     echo "Skipping deploy because branch is not master"
+  fi
+else
+  echo "Skipping deploy because it's a pull request"
+fi

--- a/budget_proj/bin/docker-push.sh
+++ b/budget_proj/bin/docker-push.sh
@@ -7,7 +7,7 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     export PATH=$PATH:$HOME/.local/bin
     docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" "$DOCKER_REPO"
     docker push "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest
-    ./bin/ecs-deploy.sh  \
+    ./$PROJ_SETTINGS_DIR/bin/ecs-deploy.sh  \
      -n "$ECS_SERVICE_NAME" \
      -c "$ECS_CLUSTER"   \
      -i "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest

--- a/budget_proj/bin/docker-push.sh
+++ b/budget_proj/bin/docker-push.sh
@@ -4,7 +4,6 @@
 if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   # Push only if we're testing the master branch
 #  if [ "$TRAVIS_BRANCH" == "master" ]; then
-    pip install --user awscli
     export PATH=$PATH:$HOME/.local/bin
     docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" "$DOCKER_REPO"
     docker push "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest

--- a/budget_proj/bin/docker-push.sh
+++ b/budget_proj/bin/docker-push.sh
@@ -5,8 +5,8 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   # Push only if we're testing the master branch
 #  if [ "$TRAVIS_BRANCH" == "master" ]; then
     export PATH=$PATH:$HOME/.local/bin
-    echo Running docker login command... # Troubleshooting
-    docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" "$DOCKER_REPO"
+    echo Getting the ECR login... # Troubleshooting
+    eval $(aws ecr get-login --region $AWS_DEFAULT_REGION)
     echo Running docker push command... # Troubleshooting
     docker push "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest
     echo Running ecs-deploy.sh script... # Troubleshooting

--- a/budget_proj/bin/docker-push.sh
+++ b/budget_proj/bin/docker-push.sh
@@ -5,8 +5,11 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   # Push only if we're testing the master branch
 #  if [ "$TRAVIS_BRANCH" == "master" ]; then
     export PATH=$PATH:$HOME/.local/bin
+    echo Running docker login command... # Troubleshooting
     docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" "$DOCKER_REPO"
+    echo Running docker push command... # Troubleshooting
     docker push "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest
+    echo Running ecs-deploy.sh script... # Troubleshooting
     ./$PROJ_SETTINGS_DIR/bin/ecs-deploy.sh  \
      -n "$ECS_SERVICE_NAME" \
      -c "$ECS_CLUSTER"   \

--- a/budget_proj/bin/ecs-deploy.sh
+++ b/budget_proj/bin/ecs-deploy.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+set -u
+
+function usage() {
+    set -e
+    cat <<EOM
+    ##### ecs-deploy #####
+    Simple script for triggering blue/green deployments on Amazon Elastic Container Service
+    https://github.com/silinternational/ecs-deploy
+    One of the following is required:
+        -n | --service-name     Name of service to deploy
+        -d | --task-definition  Name of task definition to deploy
+    Required arguments:
+        -k | --aws-access-key        AWS Access Key ID. May also be set as environment variable AWS_ACCESS_KEY_ID
+        -s | --aws-secret-key        AWS Secret Access Key. May also be set as environment variable AWS_SECRET_ACCESS_KEY
+        -r | --region                AWS Region Name. May also be set as environment variable AWS_DEFAULT_REGION
+        -p | --profile               AWS Profile to use - If you set this aws-access-key, aws-secret-key and region are needed
+        -c | --cluster               Name of ECS cluster
+        -i | --image                 Name of Docker image to run, ex: repo/image:latest
+                                     Format: [domain][:port][/repo][/][image][:tag]
+                                     Examples: mariadb, mariadb:latest, silintl/mariadb,
+                                               silintl/mariadb:latest, private.registry.com:8000/repo/image:tag
+        --aws-instance-profile  Use the IAM role associated with this instance
+    Optional arguments:
+        -D | --desired-count    The number of instantiations of the task to place and keep running in your service.
+        -m | --min              minumumHealthyPercent: The lower limit on the number of running tasks during a deployment.
+        -M | --max              maximumPercent: The upper limit on the number of running tasks during a deployment.
+        -t | --timeout          Default is 90s. Script monitors ECS Service for new task definition to be running.
+        -e | --tag-env-var      Get image tag name from environment variable. If provided this will override value specified in image name argument.
+        --max-definitions       Number of Task Definition Revisions to persist before deregistering oldest revisions.
+        -v | --verbose          Verbose output
+    Requirements:
+        aws:  AWS Command Line Interface
+        jq:   Command-line JSON processor
+    Examples:
+      Simple deployment of a service (Using env vars for AWS settings):
+        ecs-deploy -c production1 -n doorman-service -i docker.repo.com/doorman:latest
+      All options:
+        ecs-deploy -k ABC123 -s SECRETKEY -r us-east-1 -c production1 -n doorman-service -i docker.repo.com/doorman -t 240 -e CI_TIMESTAMP -v
+      Updating a task definition with a new image:
+        ecs-deploy -d open-door-task -i docker.repo.com/doorman:17
+      Using profiles (for STS delegated credentials, for instance):
+        ecs-deploy -p PROFILE -c production1 -n doorman-service -i docker.repo.com/doorman -t 240 -e CI_TIMESTAMP -v
+    Notes:
+      - If a tag is not found in image and an ENV var is not used via -e, it will default the tag to "latest"
+EOM
+
+    exit 2
+}
+if [ $# == 0 ]; then usage; fi
+
+# Check requirements
+function require {
+    command -v "$1" > /dev/null 2>&1 || {
+        echo "Some of the required software is not installed:"
+        echo "    please install $1" >&2;
+        exit 1;
+    }
+}
+
+# Check for AWS, AWS Command Line Interface
+require aws
+# Check for jq, Command-line JSON processor
+require jq
+
+# Setup default values for variables
+CLUSTER=false
+SERVICE=false
+TASK_DEFINITION=false
+MAX_DEFINITIONS=0
+IMAGE=false
+MIN=false
+MAX=false
+TIMEOUT=90
+VERBOSE=false
+TAGVAR=false
+AWS_CLI=$(which aws)
+AWS_ECS="$AWS_CLI --output json ecs"
+
+# Loop through arguments, two at a time for key and value
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+        -k|--aws-access-key)
+            AWS_ACCESS_KEY_ID="$2"
+            shift # past argument
+            ;;
+        -s|--aws-secret-key)
+            AWS_SECRET_ACCESS_KEY="$2"
+            shift # past argument
+            ;;
+        -r|--region)
+            AWS_DEFAULT_REGION="$2"
+            shift # past argument
+            ;;
+        -p|--profile)
+            AWS_PROFILE="$2"
+            shift # past argument
+            ;;
+        --aws-instance-profile)
+            echo "--aws-instance-profile is not yet in use"
+            AWS_IAM_ROLE=true
+            ;;
+        -c|--cluster)
+            CLUSTER="$2"
+            shift # past argument
+            ;;
+        -n|--service-name)
+            SERVICE="$2"
+            shift # past argument
+            ;;
+        -d|--task-definition)
+            TASK_DEFINITION="$2"
+            shift
+            ;;
+        -i|--image)
+            IMAGE="$2"
+            shift
+            ;;
+        -t|--timeout)
+            TIMEOUT="$2"
+            shift
+            ;;
+        -m|--min)
+            MIN="$2"
+            shift
+            ;;
+        -M|--max)
+            MAX="$2"
+            shift
+            ;;
+        -D|--desired-count)
+            DESIRED="$2"
+            shift
+            ;;
+        -e|--tag-env-var)
+            TAGVAR="$2"
+            shift
+            ;;
+        --max-definitions)
+            MAX_DEFINITIONS="$2"
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            ;;
+        *)
+            usage
+            exit 2
+        ;;
+    esac
+    shift # past argument or value
+done
+
+# AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION and AWS_PROFILE can be set as environment variables
+if [ -z ${AWS_ACCESS_KEY_ID+x} ]; then unset AWS_ACCESS_KEY_ID; fi
+if [ -z ${AWS_SECRET_ACCESS_KEY+x} ]; then unset AWS_SECRET_ACCESS_KEY; fi
+if [ -z ${AWS_DEFAULT_REGION+x} ];
+  then unset AWS_DEFAULT_REGION
+  else
+          AWS_ECS="$AWS_ECS --region $AWS_DEFAULT_REGION"
+fi
+if [ -z ${AWS_PROFILE+x} ];
+  then unset AWS_PROFILE
+  else
+          AWS_ECS="$AWS_ECS --profile $AWS_PROFILE"
+fi
+
+if [ $VERBOSE == true ]; then
+    set -x
+fi
+
+if [ $SERVICE == false ] && [ $TASK_DEFINITION == false ]; then
+    echo "One of SERVICE or TASK DEFINITON is required. You can pass the value using -n / --service-name for a service, or -d / --task-definiton for a task"
+    exit 1
+fi
+if [ $SERVICE != false ] && [ $TASK_DEFINITION != false ]; then
+    echo "Only one of SERVICE or TASK DEFINITON may be specified, but you supplied both"
+    exit 1
+fi
+if [ $SERVICE != false ] && [ $CLUSTER == false ]; then
+    echo "CLUSTER is required. You can pass the value using -c or --cluster"
+    exit 1
+fi
+if [ $IMAGE == false ]; then
+    echo "IMAGE is required. You can pass the value using -i or --image"
+    exit 1
+fi
+if ! [[ $MAX_DEFINITIONS =~ ^-?[0-9]+$ ]]; then
+    echo "MAX_DEFINITIONS must be numeric, or not defined."
+    exit 1
+fi
+
+# Define regex for image name
+# This regex will create groups for:
+# - domain
+# - port
+# - repo
+# - image
+# - tag
+# If a group is missing it will be an empty string
+imageRegex="^([a-zA-Z0-9.\-]+):?([0-9]+)?/([a-zA-Z0-9._-]+)/?([a-zA-Z0-9._-]+)?:?([a-zA-Z0-9\._-]+)?$"
+
+if [[ $IMAGE =~ $imageRegex ]]; then
+  # Define variables from matching groups
+  domain=${BASH_REMATCH[1]}
+  port=${BASH_REMATCH[2]}
+  repo=${BASH_REMATCH[3]}
+  img=${BASH_REMATCH[4]}
+  tag=${BASH_REMATCH[5]}
+
+  # Validate what we received to make sure we have the pieces needed
+  if [[ "x$domain" == "x" ]]; then
+    echo "Image name does not contain a domain or repo as expected. See usage for supported formats." && exit 1;
+  fi
+  if [[ "x$repo" == "x" ]]; then
+    echo "Image name is missing the actual image name. See usage for supported formats." && exit 1;
+  fi
+
+  # When a match for image is not found, the image name was picked up by the repo group, so reset variables
+  if [[ "x$img" == "x" ]]; then
+    img=$repo
+    repo=""
+  fi
+
+else
+  # check if using root level repo with format like mariadb or mariadb:latest
+  rootRepoRegex="^([a-zA-Z0-9\-]+):?([a-zA-Z0-9\.\-]+)?$"
+  if [[ $IMAGE =~ $rootRepoRegex ]]; then
+    img=${BASH_REMATCH[1]}
+    if [[ "x$img" == "x" ]]; then
+      echo "Invalid image name. See usage for supported formats." && exit 1
+    fi
+    tag=${BASH_REMATCH[2]}
+  else
+    echo "Unable to parse image name: $IMAGE, check the format and try again" && exit 1
+  fi
+fi
+
+# If tag is missing make sure we can get it from env var, or use latest as default
+if [[ "x$tag" == "x" ]]; then
+  if [[ $TAGVAR == false ]]; then
+    tag="latest"
+  else
+    tag=${!TAGVAR}
+    if [[ "x$tag" == "x" ]]; then
+      tag="latest"
+    fi
+  fi
+fi
+
+# Reassemble image name
+useImage=""
+if [[ ! -z ${domain+undefined-guard} ]]; then
+  useImage="$domain"
+fi
+if [[ ! -z ${port} ]]; then
+  useImage="$useImage:$port"
+fi
+if [[ ! -z ${repo+undefined-guard} ]]; then
+ if [[ ! "x$repo" == "x" ]]; then
+  useImage="$useImage/$repo"
+ fi
+fi
+if [[ ! -z ${img+undefined-guard} ]]; then
+  if [[ "x$useImage" == "x" ]]; then
+    useImage="$img"
+  else
+    useImage="$useImage/$img"
+  fi
+fi
+imageWithoutTag="$useImage"
+if [[ ! -z ${tag+undefined-guard} ]]; then
+  useImage="$useImage:$tag"
+fi
+
+echo "Using image name: $useImage"
+
+if [ $SERVICE != false ]; then
+  # Get current task definition name from service
+  TASK_DEFINITION=`$AWS_ECS describe-services --services $SERVICE --cluster $CLUSTER | jq -r .services[0].taskDefinition`
+fi
+
+echo "Current task definition: $TASK_DEFINITION";
+
+# Get a JSON representation of the current task definition
+# + Update definition to use new image name
+# + Filter the def
+DEF=$( $AWS_ECS describe-task-definition --task-def $TASK_DEFINITION \
+        | sed -e "s|\"image\": *\"${imageWithoutTag}:.*\"|\"image\": \"${useImage}\"|g" \
+        | sed -e "s|\"image\": *\"${imageWithoutTag}\"|\"image\": \"${useImage}\"|g" \
+        | jq '.taskDefinition' )
+
+# Default JQ filter for new task definition
+NEW_DEF_JQ_FILTER="family: .family, volumes: .volumes, containerDefinitions: .containerDefinitions"
+
+# Some options in task definition should only be included in new definition if present in
+# current definition. If found in current definition, append to JQ filter.
+CONDITIONAL_OPTIONS=(networkMode taskRoleArn)
+for i in "${CONDITIONAL_OPTIONS[@]}"; do
+  re=".*${i}.*"
+  if [[ "$DEF" =~ $re ]]; then
+    NEW_DEF_JQ_FILTER="${NEW_DEF_JQ_FILTER}, ${i}: .${i}"
+  fi
+done
+
+# Build new DEF with jq filter
+NEW_DEF=$(echo $DEF | jq "{${NEW_DEF_JQ_FILTER}}")
+
+# Register the new task definition, and store its ARN
+  NEW_TASKDEF=`$AWS_ECS register-task-definition --cli-input-json "$NEW_DEF" | jq -r .taskDefinition.taskDefinitionArn`
+echo "New task definition: $NEW_TASKDEF";
+
+if [ $SERVICE == false ]; then
+  echo "Task definition updated successfully"
+else
+  DEPLOYMENT_CONFIG=""
+  if [ $MAX != false ]; then
+    DEPLOYMENT_CONFIG=",maximumPercent=$MAX"
+  fi
+  if [ $MIN != false ]; then
+    DEPLOYMENT_CONFIG="$DEPLOYMENT_CONFIG,minimumHealthyPercent=$MIN"
+  fi
+  if [ ! -z "$DEPLOYMENT_CONFIG" ]; then
+    DEPLOYMENT_CONFIG="--deployment-configuration ${DEPLOYMENT_CONFIG:1}"
+  fi
+
+  DESIRED_COUNT=""
+  if [ ! -z ${DESIRED+undefined-guard} ]; then
+    DESIRED_COUNT="--desired-count $DESIRED"
+  fi
+
+  # Update the service
+  UPDATE=`$AWS_ECS update-service --cluster $CLUSTER --service $SERVICE $DESIRED_COUNT --task-definition $NEW_TASKDEF $DEPLOYMENT_CONFIG`
+
+  # Only excepts RUNNING state from services whose desired-count > 0
+  SERVICE_DESIREDCOUNT=`$AWS_ECS describe-services --cluster $CLUSTER --service $SERVICE | jq '.services[]|.desiredCount'`
+  if [ $SERVICE_DESIREDCOUNT -gt 0 ]; then
+    # See if the service is able to come up again
+    every=10
+    i=0
+    while [ $i -lt $TIMEOUT ]
+    do
+      # Scan the list of running tasks for that service, and see if one of them is the
+      # new version of the task definition
+
+      RUNNING_TASKS=$($AWS_ECS list-tasks --cluster "$CLUSTER"  --service-name "$SERVICE" --desired-status RUNNING \
+          | jq -r '.taskArns[]')
+
+      if [[ ! -z $RUNNING_TASKS ]] ; then
+        RUNNING=$($AWS_ECS describe-tasks --cluster "$CLUSTER" --tasks $RUNNING_TASKS \
+          | jq ".tasks[]| if .taskDefinitionArn == \"$NEW_TASKDEF\" then . else empty end|.lastStatus" \
+          | grep -e "RUNNING") || :
+
+        if [ "$RUNNING" ]; then
+          echo "Service updated successfully, new task definition running.";
+
+          if [[ $MAX_DEFINITIONS -gt 0 ]]; then
+            FAMILY_PREFIX=${TASK_DEFINITION##*:task-definition/}
+            FAMILY_PREFIX=${FAMILY_PREFIX%*:[0-9]*}
+            TASK_REVISIONS=`$AWS_ECS list-task-definitions --family-prefix $FAMILY_PREFIX --status ACTIVE --sort ASC`
+
+            NUM_ACTIVE_REVISIONS=$(echo "$TASK_REVISIONS" | jq ".taskDefinitionArns|length")
+
+            if [[ $NUM_ACTIVE_REVISIONS -gt $MAX_DEFINITIONS ]]; then
+                LAST_OUTDATED_INDEX=$(($NUM_ACTIVE_REVISIONS - $MAX_DEFINITIONS - 1))
+                for i in $(seq 0 $LAST_OUTDATED_INDEX); do
+                    OUTDATED_REVISION_ARN=$(echo "$TASK_REVISIONS" | jq -r ".taskDefinitionArns[$i]")
+
+                    echo "Deregistering outdated task revision: $OUTDATED_REVISION_ARN"
+
+                    $AWS_ECS deregister-task-definition --task-definition "$OUTDATED_REVISION_ARN" > /dev/null
+                done
+            fi
+          fi
+
+          exit 0
+        fi
+      fi
+
+      sleep $every
+      i=$(( $i + $every ))
+    done
+
+    # Timeout
+    echo "ERROR: New task definition not running within $TIMEOUT seconds"
+    exit 1
+  else
+    echo "Skipping check for running task definition, as desired-count <= 0"
+  fi
+fi

--- a/budget_proj/bin/env-template.sh
+++ b/budget_proj/bin/env-template.sh
@@ -1,8 +1,9 @@
 #! /bin/bash
 
-# This sets up access for other scripts to the app's subdirectory
-export PROJ_SETTINGS_DIR=budget_proj
+export PROJ_SETTINGS_DIR=budget_proj # This sets up access for other scripts to the app's subdirectory
+export DOCKER_IMAGE=budget-service # This is used to identify the service being run by test-proj.sh
 
+###############
 # NOTE: as of 2017-03-20, the following configuration pattern is not in use for secrets management
 # see budget_proj/project_config_template.py for the supported configuration file
 
@@ -17,7 +18,7 @@ export DATABASE_PORT='5432'
 export DATABASE_USER='PUT_DATABASE_LOGIN_ID_HERE'
 export DATABASE_PASSWORD='PUT_DATABASE_PASSWORD_HERE'
 export DJANGO_SECRET_KEY='PUT_DJANGO_SECRET_HERE'
-
+###############
 
 echo "##############################"
 echo  LOCAL CONFIG SETTINGS
@@ -29,4 +30,5 @@ echo "##############################"
 #echo  DATABASE_USER $DATABASE_USER
 #echo  DATABASE_PASSWORD $DATABASE_PASSWORD
 #echo  DJANGO_SECRET_KEY $DJANGO_SECRET_KEY
+echo  DOCKER_IMAGE $DOCKER_IMAGE
 echo  PROJ_SETTINGS_DIR $PROJ_SETTINGS_DIR

--- a/budget_proj/bin/getconfig.sh
+++ b/budget_proj/bin/getconfig.sh
@@ -8,8 +8,6 @@ echo "##############################"
 echo  Running getconfig.sh...
 echo  CONFIG SETTINGS
 echo "##############################"
-echo  CONFIG_BUCKET $CONFIG_BUCKET
-echo  DEPLOY_TARGET $DEPLOY_TARGET
 echo  PROJ_SETTINGS_DIR $PROJ_SETTINGS_DIR
 
 if [ "$DEPLOY_TARGET" == "local" ]; then
@@ -17,9 +15,11 @@ if [ "$DEPLOY_TARGET" == "local" ]; then
     echo -e  USING LOCAL CONFIG - MAKE SURE YOU HAVE A LOCAL CONFIG in bin/$CONFIG_FILE
     echo -e "#####################################################"
 else
+    echo  CONFIG_BUCKET $CONFIG_BUCKET
+    echo  DEPLOY_TARGET $DEPLOY_TARGET
     echo -e "########################################"
-    echo -e  "USING $DEPLOY_TARGET CONFIG"
     echo -e  "USING THE $CONFIG_BUCKET CONFIG BUCKET"
+    echo -e  "USING $DEPLOY_TARGET CONFIG"
     echo -e "########################################"
     export PATH=$PATH:~/.local/bin # TODO is this necessary for anything?
     aws s3 cp \

--- a/budget_proj/bin/test-entrypoint.sh
+++ b/budget_proj/bin/test-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 export PATH=$PATH:~/.local/bin
-./bin/getconfig.sh
+#./bin/getconfig.sh
 #python manage.py migrate --noinput
 python manage.py test --no-input

--- a/budget_proj/bin/test-proj.sh
+++ b/budget_proj/bin/test-proj.sh
@@ -14,8 +14,11 @@ while getopts ":lt" opt; do
           run $DOCKER_IMAGE python manage.py test --no-input
           ;;
         t)
-          docker-compose -f $PROJ_SETTINGS_DIR/travis-docker-compose.yml \
-          run $DOCKER_IMAGE python manage.py test --no-input
+          docker-compose -f $PROJ_SETTINGS_DIR/travis-docker-compose.yml build
+          docker-compose -f $PROJ_SETTINGS_DIR/travis-docker-compose.yml run \
+          --entrypoint /code/bin/test-entrypoint.sh $DOCKER_IMAGE
+#          docker-compose -f $PROJ_SETTINGS_DIR/travis-docker-compose.yml \
+#          run $DOCKER_IMAGE python manage.py test --no-input
           ;;
         *)
           usage

--- a/budget_proj/bin/test-proj.sh
+++ b/budget_proj/bin/test-proj.sh
@@ -11,11 +11,11 @@ while getopts ":lt" opt; do
     case "$opt" in
         l)
           docker-compose -f $PROJ_SETTINGS_DIR/local-docker-compose.yml \
-          run budget-service python manage.py test --no-input
+          run $DOCKER_IMAGE python manage.py test --no-input
           ;;
         t)
           docker-compose -f $PROJ_SETTINGS_DIR/travis-docker-compose.yml \
-          run budget-service python manage.py test --no-input
+          run $DOCKER_IMAGE python manage.py test --no-input
           ;;
         *)
           usage

--- a/budget_proj/bin/test-proj.sh
+++ b/budget_proj/bin/test-proj.sh
@@ -10,8 +10,9 @@ echo  Running test_proj.sh...
 while getopts ":lt" opt; do
     case "$opt" in
         l)
-          docker-compose -f $PROJ_SETTINGS_DIR/local-docker-compose.yml \
-          run $DOCKER_IMAGE python manage.py test --no-input
+          docker-compose -f $PROJ_SETTINGS_DIR/local-docker-compose.yml build
+          docker-compose -f $PROJ_SETTINGS_DIR/local-docker-compose.yml run \
+          --entrypoint /code/bin/test-entrypoint.sh $DOCKER_IMAGE
           ;;
         t)
           docker-compose -f $PROJ_SETTINGS_DIR/travis-docker-compose.yml build

--- a/budget_proj/bin/test-proj.sh
+++ b/budget_proj/bin/test-proj.sh
@@ -17,8 +17,6 @@ while getopts ":lt" opt; do
           docker-compose -f $PROJ_SETTINGS_DIR/travis-docker-compose.yml build
           docker-compose -f $PROJ_SETTINGS_DIR/travis-docker-compose.yml run \
           --entrypoint /code/bin/test-entrypoint.sh $DOCKER_IMAGE
-#          docker-compose -f $PROJ_SETTINGS_DIR/travis-docker-compose.yml \
-#          run $DOCKER_IMAGE python manage.py test --no-input
           ;;
         *)
           usage

--- a/budget_proj/budget_app/tests.py
+++ b/budget_proj/budget_app/tests.py
@@ -15,7 +15,7 @@ class TestCodeEndpoint(TestCase):
         self.client = Client()
 
     def test(self):
-        response = self.client.get('/code/')
+        response = self.client.get('/budget/code/')
 
         self.assertEqual(response.status_code, 200)
 
@@ -24,7 +24,7 @@ class TestHistoryEndpoint(TestCase):
         self.client = Client()
 
     def test(self):
-        response = self.client.get('/history/')
+        response = self.client.get('/budget/history/')
 
         self.assertEqual(response.status_code, 200)
 
@@ -33,7 +33,7 @@ class TestKpmEndpoint(TestCase):
         self.client = Client()
 
     def test(self):
-        response = self.client.get('/kpm/')
+        response = self.client.get('/budget/kpm/')
 
         self.assertEqual(response.status_code, 200)
 
@@ -42,6 +42,6 @@ class TestOcrbEndpoint(TestCase):
         self.client = Client()
 
     def test(self):
-        response = self.client.get('/ocrb/')
+        response = self.client.get('/budget/ocrb/')
 
         self.assertEqual(response.status_code, 200)

--- a/budget_proj/budget_proj/settings.py
+++ b/budget_proj/budget_proj/settings.py
@@ -142,7 +142,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
-STATIC_URL = "/static/"
+STATIC_URL = "/budget/static/"
 
 # This seems to be necessary to enable the Django app to correctly style
 # the Swagger wrapper when the Django app runs inside a Docker container

--- a/budget_proj/budget_proj/urls.py
+++ b/budget_proj/budget_proj/urls.py
@@ -21,7 +21,7 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^', include('budget_app.urls', namespace='budget_app')),
+    url(r'^budget/', include('budget_app.urls', namespace='budget_app')),
 ]
 
 # This statement is necessary to enable Swagger styling to work when the app runs in Docker container

--- a/budget_proj/local-docker-compose.yml
+++ b/budget_proj/local-docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 services:
   budget-service:
     environment:
@@ -8,7 +8,6 @@ services:
     - DEPLOY_TARGET=${DEPLOY_TARGET}
     - PROJ_SETTINGS_DIR=${PROJ_SETTINGS_DIR}
     build: .
-    image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest" # troubleshooting only
     command: /code/bin/docker-entrypoint.sh
     volumes:
       - .:/code

--- a/budget_proj/local-docker-compose.yml
+++ b/budget_proj/local-docker-compose.yml
@@ -1,13 +1,16 @@
-budget-service:
-  environment:
-  - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-  - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-  - CONFIG_BUCKET=${CONFIG_BUCKET}  
-  - DEPLOY_TARGET=${DEPLOY_TARGET}
-  - PROJ_SETTINGS_DIR=${PROJ_SETTINGS_DIR}
-  build: .
-  command: /code/bin/docker-entrypoint.sh
-  volumes:
-    - .:/code
-  ports:
-    - "8000:8000"
+version: "3"
+services:
+  budget-service:
+    environment:
+    - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+    - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    - CONFIG_BUCKET=${CONFIG_BUCKET}  
+    - DEPLOY_TARGET=${DEPLOY_TARGET}
+    - PROJ_SETTINGS_DIR=${PROJ_SETTINGS_DIR}
+    build: .
+    image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest" # troubleshooting only
+    command: /code/bin/docker-entrypoint.sh
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"

--- a/budget_proj/travis-docker-compose.yml
+++ b/budget_proj/travis-docker-compose.yml
@@ -6,7 +6,7 @@ budget-service:
   - DEPLOY_TARGET=${DEPLOY_TARGET}
   - PROJ_SETTINGS_DIR=${PROJ_SETTINGS_DIR}
   build: .
-  image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest"
+#  image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest"
   volumes:
     - .:/code
   ports:

--- a/budget_proj/travis-docker-compose.yml
+++ b/budget_proj/travis-docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 services:
   budget-service:
     environment:

--- a/budget_proj/travis-docker-compose.yml
+++ b/budget_proj/travis-docker-compose.yml
@@ -6,7 +6,12 @@ budget-service:
   - DEPLOY_TARGET=${DEPLOY_TARGET}
   - PROJ_SETTINGS_DIR=${PROJ_SETTINGS_DIR}
   build: .
-#  image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest"
+
+# docker-compose complains if I enable the image key at the same time as the build key
+# "ERROR: The Compose file is invalid because:
+# "Service budget-service has both an image and build path specified. A service can either be built to image or use an existing image, not both."
+
+#  image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest" 
   volumes:
     - .:/code
   ports:

--- a/budget_proj/travis-docker-compose.yml
+++ b/budget_proj/travis-docker-compose.yml
@@ -4,11 +4,12 @@ services:
     environment:
     - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-    - CONFIG_BUCKET=${CONFIG_BUCKET}  
+    - CONFIG_BUCKET=${CONFIG_BUCKET}
     - DEPLOY_TARGET=${DEPLOY_TARGET}
     - PROJ_SETTINGS_DIR=${PROJ_SETTINGS_DIR}
     build: .
-    image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest" 
+    image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest"
+    command: /code/bin/docker-entrypoint.sh
     volumes:
       - .:/code
     ports:

--- a/budget_proj/travis-docker-compose.yml
+++ b/budget_proj/travis-docker-compose.yml
@@ -6,6 +6,7 @@ budget-service:
   - DEPLOY_TARGET=${DEPLOY_TARGET}
   - PROJ_SETTINGS_DIR=${PROJ_SETTINGS_DIR}
   build: .
+  image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest"
   volumes:
     - .:/code
   ports:

--- a/budget_proj/travis-docker-compose.yml
+++ b/budget_proj/travis-docker-compose.yml
@@ -1,18 +1,15 @@
-budget-service:
-  environment:
-  - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-  - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-  - CONFIG_BUCKET=${CONFIG_BUCKET}  
-  - DEPLOY_TARGET=${DEPLOY_TARGET}
-  - PROJ_SETTINGS_DIR=${PROJ_SETTINGS_DIR}
-  build: .
-
-# docker-compose complains if I enable the image key at the same time as the build key
-# "ERROR: The Compose file is invalid because:
-# "Service budget-service has both an image and build path specified. A service can either be built to image or use an existing image, not both."
-
-  image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest" 
-  volumes:
-    - .:/code
-  ports:
-    - "8000:8000"
+version: "3"
+services:
+  budget-service:
+    environment:
+    - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+    - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    - CONFIG_BUCKET=${CONFIG_BUCKET}  
+    - DEPLOY_TARGET=${DEPLOY_TARGET}
+    - PROJ_SETTINGS_DIR=${PROJ_SETTINGS_DIR}
+    build: .
+    image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest" 
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"

--- a/budget_proj/travis-docker-compose.yml
+++ b/budget_proj/travis-docker-compose.yml
@@ -11,7 +11,7 @@ budget-service:
 # "ERROR: The Compose file is invalid because:
 # "Service budget-service has both an image and build path specified. A service can either be built to image or use an existing image, not both."
 
-#  image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest" 
+  image: "${DOCKER_REPO}/${DEPLOY_TARGET}/${DOCKER_IMAGE}:latest" 
   volumes:
     - .:/code
   ports:


### PR DESCRIPTION
We now have successful deployment to AWS ECS (EC2 Container Service).

This makes our project only the second to complete deployment of a Docker container **with integrated testing** into the INTEGRATION environment in AWS.

You can find the live INTEGRATION (i.e. non-production) endpoints responding here:
http://hacko-integration-658279555.us-west-2.elb.amazonaws.com/budget/

# Developer Notes

The hosting of all containerized APIs under one roof necessitated using a single FQDN and hosting each project's API's beneath a named route e.g. `/budget`.

This means that when you test out the Docker container locally, from now on instead of browsing to http://localhost:8000/, you'll have to browse to http://localhost:8000/budget.  The `/` route is currently not configured to redirect (I couldn't find a pattern anywhere to copy from, but a PR to fix this would definitely help for local testing).  This is of course irrelevant in AWS-land, since the `/` route is occupied by the [Civic Lab Frontend](http://hacko-integration-658279555.us-west-2.elb.amazonaws.com/) (currently just a placeholder).

# Testing

Again, as a DevOps/deployment operation, there's not much in the way of offline testing other developers can do.

However, to validate that this hasn't broken the local usage models, please try the following:
- `git pull`
- `git checkout mikethecanuck/enable-cd`
- `budget_proj/bin/start-proj.sh` (if you wish to browse to the container's hosted endpoints at http://localhost:8000/budget) or `budget_proj/bin/test-proj.sh` if you wish to validate that the test cases are still executing and succeeding