### PR TITLE
New tests: verify the APIs return JSON data

### DIFF
--- a/budget_proj/budget_app/tests.py
+++ b/budget_proj/budget_app/tests.py
@@ -1,12 +1,13 @@
-from django.test import TestCase, Client
-from django.urls import reverse
-from budget_app.models import OCRB
-from mixer.backend.django import mixer
-from rest_framework import status
-from rest_framework.test import APITestCase
 import json # enables inspecting JSON data for certain fields
+from django.test import TestCase, Client
+# NOTE: disabled these for now but expect they'll be used in the near future
+# from django.urls import reverse
+# from budget_app.models import OCRB
+# from mixer.backend.django import mixer
+# from rest_framework import status
+# from rest_framework.test import APITestCase
 
-# Ideas:
+# Other Ideas:
 # - http://stackoverflow.com/questions/24904362/how-to-write-unit-tests-for-django-rest-framework-apis
 # - https://github.com/hackoregon/hacku-devops-2017/wiki/Assignment-5
 # - http://www.django-rest-framework.org/api-guide/testing/

--- a/budget_proj/budget_app/tests.py
+++ b/budget_proj/budget_app/tests.py
@@ -28,7 +28,7 @@ class TestCodeEndpoint(TestCase):
         codes = [item["code"] for item in json_content]
 
         for code in codes:
-            self.assertEqual(code, AT)
+            self.assertEqual(code, 'AT')
 
 class TestHistoryEndpoint(TestCase):
     def setup(self):
@@ -46,7 +46,7 @@ class TestHistoryEndpoint(TestCase):
         fiscal_years = [item["fiscal_year"] for item in json_content]
 
         for fiscal_year in fiscal_years:
-            self.assertEqual(fiscal_year, 2015-16)
+            self.assertEqual(fiscal_year, '2015-16')
 
 class TestKpmEndpoint(TestCase):
     def setup(self):
@@ -64,7 +64,7 @@ class TestKpmEndpoint(TestCase):
         fiscal_years = [item["fy"] for item in json_content]
 
         for fiscal_year in fiscal_years:
-            self.assertEqual(fiscal_year, 2015-16)
+            self.assertEqual(fiscal_year, '2015-16')
 
 class TestOcrbEndpoint(TestCase):
     def setup(self):
@@ -82,4 +82,4 @@ class TestOcrbEndpoint(TestCase):
         fiscal_years = [item["fy"] for item in json_content]
 
         for fiscal_year in fiscal_years:
-            self.assertEqual(fiscal_year, 2015-16)
+            self.assertEqual(fiscal_year, '2015-16')

--- a/budget_proj/budget_app/tests.py
+++ b/budget_proj/budget_app/tests.py
@@ -4,6 +4,7 @@ from budget_app.models import OCRB
 from mixer.backend.django import mixer
 from rest_framework import status
 from rest_framework.test import APITestCase
+import json # enables inspecting JSON data for certain fields
 
 # Ideas:
 # - http://stackoverflow.com/questions/24904362/how-to-write-unit-tests-for-django-rest-framework-apis
@@ -19,6 +20,15 @@ class TestCodeEndpoint(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_code_get_request_works_with_query_param(self):
+        response = self.client.get("/budget/code/?code=AT")
+        self.assertEqual(response.status_code, 200)
+        json_content = json.loads(response.content.decode('utf-8'))
+        codes = [item["code"] for item in json_content]
+
+        for code in codes:
+            self.assertEqual(code, AT)
+
 class TestHistoryEndpoint(TestCase):
     def setup(self):
         self.client = Client()
@@ -27,6 +37,15 @@ class TestHistoryEndpoint(TestCase):
         response = self.client.get('/budget/history/')
 
         self.assertEqual(response.status_code, 200)
+
+    def test_history_get_request_works_with_query_param(self):
+        response = self.client.get("/budget/history/?fiscal_year=2015-16&bureau_code=PS")
+        self.assertEqual(response.status_code, 200)
+        json_content = json.loads(response.content.decode('utf-8'))
+        fiscal_years = [item["fiscal_year"] for item in json_content]
+
+        for fiscal_year in fiscal_years:
+            self.assertEqual(fiscal_year, 2015-16)
 
 class TestKpmEndpoint(TestCase):
     def setup(self):
@@ -37,6 +56,15 @@ class TestKpmEndpoint(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_kpm_get_request_works_with_query_param(self):
+        response = self.client.get("/budget/kpm/?fy=2015-16")
+        self.assertEqual(response.status_code, 200)
+        json_content = json.loads(response.content.decode('utf-8'))
+        fiscal_years = [item["fy"] for item in json_content]
+
+        for fiscal_year in fiscal_years:
+            self.assertEqual(fiscal_year, 2015-16)
+
 class TestOcrbEndpoint(TestCase):
     def setup(self):
         self.client = Client()
@@ -45,3 +73,12 @@ class TestOcrbEndpoint(TestCase):
         response = self.client.get('/budget/ocrb/')
 
         self.assertEqual(response.status_code, 200)
+
+    def test_ocrb_get_request_works_with_query_param(self):
+        response = self.client.get("/budget/ocrb/?fy=2015-16")
+        self.assertEqual(response.status_code, 200)
+        json_content = json.loads(response.content.decode('utf-8'))
+        fiscal_years = [item["fy"] for item in json_content]
+
+        for fiscal_year in fiscal_years:
+            self.assertEqual(fiscal_year, 2015-16)


### PR DESCRIPTION
# Goal

Determine whether anything has broken the API response such that non-JSON data gets returned.

# Details
I've added tests, based on [homelessness project](https://github.com/hackoregon/teamHomelessness/blob/master/homelessAPI/homelessApp/tests.py), to verify that expected JSON data is being returned from API requests.

For each endpoint, the test only verifies a single field (e.g. "fy" or "fiscal_year" where that field exists, and "code" for the /code endpoint).

# Testing

You can verify the tests are working in the Travis builds by reviewing [this build](
https://travis-ci.org/hackoregon/team-budget/builds/214398088), lines 425-431.

To verify the tests run in your local environment:
- `git pull`
- `git checkout mikethecanuck/tests-for-api-data`
- `budget_proj/bin/test-proj.sh -l`

You should see the end of the output resemble this:

```
Successfully built 279021faff82
Creating test database for alias 'default'...
........
----------------------------------------------------------------------
Ran 8 tests in 0.735s

OK
Destroying test database for alias 'default'...
```