### PR TITLE
Replace sync workers with eventlet workers to eliminate the [CRITICAL] WORKER TIMEOUT errors

### DIFF
--- a/budget_proj/bin/docker-entrypoint.sh
+++ b/budget_proj/bin/docker-entrypoint.sh
@@ -7,4 +7,4 @@ echo  Running docker-entrypoint.sh...
 #python manage.py collectstatic --no-input
 
 # Fire up a lightweight frontend to host the Django endpoints - gunicorn was the default choice
-gunicorn budget_proj.wsgi:application -b :8000
+gunicorn budget_proj.wsgi:application -b :8000 --timeout 90 -w 5 -k 'eventlet' # eventlet used to address ELB/gunicorn issue here https://github.com/benoitc/gunicorn/issues/1194

--- a/budget_proj/requirements.txt
+++ b/budget_proj/requirements.txt
@@ -12,3 +12,4 @@ six==1.10.0
 
 gunicorn
 mixer==5.6.6
+eventlet # to address ELB/gunicorn issue here https://github.com/benoitc/gunicorn/issues/1194


### PR DESCRIPTION
If you're following the ridiculously thorough investigations, Brian Grant and I are chasing down the source of the [CRITICAL] WORKER TIMEOUT errors we're seeing in most of the containers - see [Devops-17 Issue 49](https://github.com/hackoregon/devops-17/issues/49) for details.

It appears that we're suffering from some confluence of behaviours that only shows up with ELB, Docker and gunicorn are used together to host applications in a load-balanced cluster.

There are multiple reports from [this gunicorn issue](https://github.com/benoitc/gunicorn/issues/1194) that the "sync" worker default is largely implicated, and that switching to the "gevent" worker type mitigates the issue.  [I'm still not entirely convinced that this is the right architectural decision - there ought to be a way to address the root cause, as in causing ELB/ALB to stop tying up sync workers until it causes the very "unhealthy" state that it is attempting to test for.  However, the mathematics and internal behaviour characteristics of ALB's Health Check algorithms vs the configuration options are beyond my ability to reason out right now - and we have to get the damned APIs deploying in a healthy state before we worry about doing things "right".] 

This patch should address the issue in two ways:
- replacing the "sync" worker that is too permissive to the keepalive TCP connection from ALB Health Check requests
- increasing the number of listening workers to reduce the odds of ALB tying up all available workers