### PR TITLE
Removes data rows with zero amount.

### DIFF
--- a/Data/README_DataSources.md
+++ b/Data/README_DataSources.md
@@ -2,4 +2,4 @@
 
 `HackOregon_hx_budget_data_ASV2_extracted.csv` is a CSV export from the [Hack Oregon hx budget data ASV2.xlsx](https://drive.google.com/open?id=0B7CgmR-dA_1KV2p6MzRaenM1VHc) spreadsheet, which contains `Actual` historical data exported from the Portland City Budget database. Unfortunately, we do not have any documentation of the database query that produced the spreadsheet.
 
-`HackOregon_hx_budget_data_ASV2_transformed.csv` was derived from the `HackOregon_hx_budget_data_ASV2_extracted.csv` file, using the R script `HackOregon_hx_budget_data_ASV2_transform.R`.
+`HackOregon_hx_budget_data_ASV2_transformed.csv` and `HackOregon_hx_budget_data_ASV2_nonzero.csv` were derived from the `HackOregon_hx_budget_data_ASV2_extracted.csv` file, using the R script `HackOregon_hx_budget_data_ASV2_transform.R`. See that script in the R directory for an explanation of how "extracted" data was made into "tidy" data in the "transformed" file. Rows with zero amounts were then removed to create the "nonzero" file to be used to load the database.

--- a/R/HackOregon_hx_budget_data_ASV2_transform.R
+++ b/R/HackOregon_hx_budget_data_ASV2_transform.R
@@ -35,6 +35,7 @@ baseFileName <- "HackOregon_hx_budget_data_ASV2"
 csvSuffix <- ".csv"
 originalModifier <- "_extracted"
 transformedModifier <- "_transformed"
+nonzeroModifier <- "_nonzero"
 
 dfExtracted <- read.csv(paste0(dataDirectory, baseFileName, originalModifier, csvSuffix), stringsAsFactors = FALSE)
 
@@ -76,3 +77,7 @@ str(dfTidy)
 
 write.csv(dfTidy, paste0(dataDirectory, baseFileName, transformedModifier, csvSuffix), row.names = FALSE)
 
+# Removes rows with zero amount.
+dfTidyNonZero <- dfTidy[dfTidy$amount != 0, ]
+dim(dfTidyNonZero)
+write.csv(dfTidyNonZero, paste0(dataDirectory, baseFileName, nonzeroModifier, csvSuffix), row.names = FALSE)


### PR DESCRIPTION
I added to the R code to remove row that have amount == 0 per John's suggestion. This makes the CSV data file `HackOregon_hx_budget_data_ASV2_nonzero.csv` to be only 42% the size of `HackOregon_hx_budget_data_ASV2_transformed.csv`. There is no loss of functionality, because at this point we are only using the `amount` field to calculate totals, so there is no problem if the zero amount rows are excluded from the data.