### PR TITLE
Ignore budget_db.sqlite3 file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ budget_venv
 *.pyc
 .DS_Store
 .idea/*
-budget_proj/budget_db.sqlite3
+budget_db.sqlite3
 env.sh
 project_config.py
 static/


### PR DESCRIPTION
Fixed `.gitignore` to ignore the `budget_db.sqlite3` file always, regardless of the directory in which it is created. That file is only used for local development and should not be committed to the team's repository.

`budget_db.sqlite3` is created in the directory from which the `runserver` call is made. For me, that is the top level `team-budget` directory. Other people run `runserver` from the `team-budget/budget_proj` directory.