### PR TITLE
Documenting the use of Gevent worker

### DIFF
--- a/budget_proj/bin/docker-entrypoint.sh
+++ b/budget_proj/bin/docker-entrypoint.sh
@@ -7,7 +7,4 @@ echo  Running docker-entrypoint.sh...
 python manage.py collectstatic --no-input
 
 # Fire up a lightweight frontend to host the Django endpoints - gunicorn was the default choice
-gunicorn budget_proj.wsgi:application -b :8000 --keep-alive 60 --worker-class 'gevent'
-
-# Reconsider this approach if we figure out why it did not help in PR 94
-#gunicorn budget_proj.wsgi:application -b :8000 --timeout 90 -w 5 -k 'eventlet' # eventlet used to address ELB/gunicorn issue here https://github.com/benoitc/gunicorn/issues/1194
+gunicorn budget_proj.wsgi:application -b :8000 --keep-alive 60 --worker-class 'gevent' # gevent used to address ELB/gunicorn issue here https://github.com/benoitc/gunicorn/issues/1194


### PR DESCRIPTION
Gevent worker is there to workaround the assumption that ALB is still running into the same [ELB/gunicorn issue discussed here](https://github.com/benoitc/gunicorn/issues/1194).