### PR TITLE
hack pagination into ocrb view

### DIFF
--- a/budget_proj/budget_app/filters.py
+++ b/budget_proj/budget_app/filters.py
@@ -1,0 +1,39 @@
+from django.db.models import CharField
+from django_filters import rest_framework as filters
+from . import models
+
+
+# All this says is we prefer to use iexact rather than exact for char fields
+# when filtering our models based on query params
+
+
+class DefaultFilterMeta:
+    """
+    Set our default Filter configurations to DRY up the FilterSet Meta classes.
+    """
+    # Let us filter by all fields except id
+    exclude = ('id',)
+    # We prefer case insensitive matching on CharFields
+    filter_overrides = {
+        CharField: {
+            'filter_class': filters.CharFilter,
+            'extra': lambda f: {
+                'lookup_expr': 'iexact',
+            },
+        },
+    }
+
+
+class OcrbFilter(filters.FilterSet):
+    class Meta(DefaultFilterMeta):
+        model = models.OCRB
+
+
+class KpmFilter(filters.FilterSet):
+    class Meta(DefaultFilterMeta):
+        model = models.KPM
+
+
+class BudgetHistoryFilter(filters.FilterSet):
+    class Meta(DefaultFilterMeta):
+        model = models.BudgetHistory

--- a/budget_proj/budget_app/filters.py
+++ b/budget_proj/budget_app/filters.py
@@ -3,10 +3,6 @@ from django_filters import rest_framework as filters
 from . import models
 
 
-# All this says is we prefer to use iexact rather than exact for char fields
-# when filtering our models based on query params
-
-
 class DefaultFilterMeta:
     """
     Set our default Filter configurations to DRY up the FilterSet Meta classes.

--- a/budget_proj/budget_app/filters.py
+++ b/budget_proj/budget_app/filters.py
@@ -37,3 +37,10 @@ class KpmFilter(filters.FilterSet):
 class BudgetHistoryFilter(filters.FilterSet):
     class Meta(DefaultFilterMeta):
         model = models.BudgetHistory
+
+
+
+class LookupCodeFilter(filters.FilterSet):
+    class Meta(DefaultFilterMeta):
+        model = models.LookupCode
+

--- a/budget_proj/budget_app/tests.py
+++ b/budget_proj/budget_app/tests.py
@@ -21,13 +21,25 @@ class TestCodeEndpoint(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_code_get_request_works_with_query_param(self):
-        response = self.client.get("/budget/code/?code=AT")
+        response = self.client.get("/budget/code/", {'code': 'AT'})
         self.assertEqual(response.status_code, 200)
         json_content = response.json()
-        codes = [item["code"] for item in json_content]
+        code_data = json_content['results']
+        codes = [item["code"] for item in code_data]
 
         for code in codes:
             self.assertEqual(code, 'AT')
+
+    def test_code_response_is_paginated(self):
+        response = self.client.get('/budget/code/')
+
+        json = response.json()
+
+        self.assertTrue('count' in json)
+        self.assertTrue('next' in json)
+        self.assertTrue('previous' in json)
+        self.assertTrue('results' in json)
+
 
 class TestHistoryEndpoint(TestCase):
     def setup(self):
@@ -94,6 +106,7 @@ class TestKpmEndpoint(TestCase):
         # regression test
         response = self.client.get('/budget/kpm/', {'page': 1})
         self.assertEqual(response.status_code, 200)
+
 
 class TestOcrbEndpoint(TestCase):
     def setup(self):

--- a/budget_proj/budget_app/tests.py
+++ b/budget_proj/budget_app/tests.py
@@ -80,7 +80,6 @@ class TestOcrbEndpoint(TestCase):
         response = self.client.get("/budget/ocrb/?fy=2015-16")
         self.assertEqual(response.status_code, 200)
         json_content = json.loads(response.content.decode('utf-8'))
-        fiscal_years = [item["fy"] for item in json_content]
         results = json_content['results']
         fiscal_years = [item["fy"] for item in results]
 

--- a/budget_proj/budget_app/tests.py
+++ b/budget_proj/budget_app/tests.py
@@ -16,7 +16,7 @@ class TestCodeEndpoint(TestCase):
     def setup(self):
         self.client = Client()
 
-    def test(self):
+    def test_ok(self):
         response = self.client.get('/budget/code/')
 
         self.assertEqual(response.status_code, 200)
@@ -34,7 +34,7 @@ class TestHistoryEndpoint(TestCase):
     def setup(self):
         self.client = Client()
 
-    def test(self):
+    def test_ok(self):
         response = self.client.get('/budget/history/')
 
         self.assertEqual(response.status_code, 200)
@@ -52,7 +52,7 @@ class TestKpmEndpoint(TestCase):
     def setup(self):
         self.client = Client()
 
-    def test(self):
+    def test_ok(self):
         response = self.client.get('/budget/kpm/')
 
         self.assertEqual(response.status_code, 200)
@@ -67,11 +67,26 @@ class TestKpmEndpoint(TestCase):
         for fiscal_year in fiscal_years:
             self.assertEqual(fiscal_year, '2015-16')
 
+    def test_kpm_response_is_paginated(self):
+        response = self.client.get('/budget/kpm/')
+
+        json = response.json()
+
+        self.assertTrue('count' in json)
+        self.assertTrue('next' in json)
+        self.assertTrue('previous' in json)
+        self.assertTrue('results' in json)
+
+    def test_kpm_accepts_page_query_param(self):
+        # regression test
+        response = self.client.get('/budget/kpm/', {'page': 1})
+        self.assertEqual(response.status_code, 200)
+
 class TestOcrbEndpoint(TestCase):
     def setup(self):
         self.client = Client()
 
-    def test(self):
+    def test_ok(self):
         response = self.client.get('/budget/ocrb/')
 
         self.assertEqual(response.status_code, 200)
@@ -85,3 +100,19 @@ class TestOcrbEndpoint(TestCase):
 
         for fiscal_year in fiscal_years:
             self.assertEqual(fiscal_year, '2015-16')
+
+    def test_ocrb_response_is_paginated(self):
+        response = self.client.get('/budget/ocrb/')
+
+        json = response.json()
+
+        # look for pagination keys
+        self.assertTrue('count' in json)
+        self.assertTrue('next' in json)
+        self.assertTrue('previous' in json)
+        self.assertTrue('results' in json)
+
+    def test_ocrb_accepts_page_query_param(self):
+        # regression test
+        response = self.client.get('/budget/ocrb/', {'page': 1})
+        self.assertEqual(response.status_code, 200)

--- a/budget_proj/budget_app/tests.py
+++ b/budget_proj/budget_app/tests.py
@@ -61,7 +61,8 @@ class TestKpmEndpoint(TestCase):
         response = self.client.get("/budget/kpm/?fy=2015-16")
         self.assertEqual(response.status_code, 200)
         json_content = json.loads(response.content.decode('utf-8'))
-        fiscal_years = [item["fy"] for item in json_content]
+        results = json_content['results']
+        fiscal_years = [item["fy"] for item in results]
 
         for fiscal_year in fiscal_years:
             self.assertEqual(fiscal_year, '2015-16')
@@ -80,6 +81,8 @@ class TestOcrbEndpoint(TestCase):
         self.assertEqual(response.status_code, 200)
         json_content = json.loads(response.content.decode('utf-8'))
         fiscal_years = [item["fy"] for item in json_content]
+        results = json_content['results']
+        fiscal_years = [item["fy"] for item in results]
 
         for fiscal_year in fiscal_years:
             self.assertEqual(fiscal_year, '2015-16')

--- a/budget_proj/budget_app/tests.py
+++ b/budget_proj/budget_app/tests.py
@@ -1,4 +1,3 @@
-import json # enables inspecting JSON data for certain fields
 from django.test import TestCase, Client
 # NOTE: disabled these for now but expect they'll be used in the near future
 # from django.urls import reverse
@@ -24,7 +23,7 @@ class TestCodeEndpoint(TestCase):
     def test_code_get_request_works_with_query_param(self):
         response = self.client.get("/budget/code/?code=AT")
         self.assertEqual(response.status_code, 200)
-        json_content = json.loads(response.content.decode('utf-8'))
+        json_content = response.json()
         codes = [item["code"] for item in json_content]
 
         for code in codes:
@@ -40,13 +39,27 @@ class TestHistoryEndpoint(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_history_get_request_works_with_query_param(self):
-        response = self.client.get("/budget/history/?fiscal_year=2015-16&bureau_code=PS")
+        query_params = {'fiscal_year': '2015-16', 'bureau_code': 'PS'}
+        response = self.client.get("/budget/history/", query_params)
+
         self.assertEqual(response.status_code, 200)
-        json_content = json.loads(response.content.decode('utf-8'))
-        fiscal_years = [item["fiscal_year"] for item in json_content]
+
+        results = response.json()['results']
+        fiscal_years = [item["fiscal_year"] for item in results]
 
         for fiscal_year in fiscal_years:
             self.assertEqual(fiscal_year, '2015-16')
+
+    def test_history_response_is_paginated(self):
+        response = self.client.get('/budget/history/')
+
+        json = response.json()
+
+        self.assertTrue('count' in json)
+        self.assertTrue('next' in json)
+        self.assertTrue('previous' in json)
+        self.assertTrue('results' in json)
+
 
 class TestKpmEndpoint(TestCase):
     def setup(self):
@@ -60,7 +73,7 @@ class TestKpmEndpoint(TestCase):
     def test_kpm_get_request_works_with_query_param(self):
         response = self.client.get("/budget/kpm/?fy=2015-16")
         self.assertEqual(response.status_code, 200)
-        json_content = json.loads(response.content.decode('utf-8'))
+        json_content = response.json()
         results = json_content['results']
         fiscal_years = [item["fy"] for item in results]
 
@@ -94,7 +107,7 @@ class TestOcrbEndpoint(TestCase):
     def test_ocrb_get_request_works_with_query_param(self):
         response = self.client.get("/budget/ocrb/?fy=2015-16")
         self.assertEqual(response.status_code, 200)
-        json_content = json.loads(response.content.decode('utf-8'))
+        json_content = response.json()
         results = json_content['results']
         fiscal_years = [item["fy"] for item in results]
 

--- a/budget_proj/budget_app/views.py
+++ b/budget_proj/budget_app/views.py
@@ -23,6 +23,7 @@ from . import filters
 class ListOcrb(generics.ListAPIView):
     """
     Operating and Capital Requirements by Bureau (OCRB).
+    Note: Parameter values are compared case-insensitive.
     """
     serializer_class = serializers.OcrbSerializer
     filter_class = filters.OcrbFilter
@@ -64,6 +65,7 @@ class OcrbSummary(generics.ListAPIView):
 class ListKpm(generics.ListAPIView):
     """
     Key Performance Measures (KPM).
+    Note: Parameter values are compared case-insensitive.
     """
     queryset = models.KPM.objects.all()
     serializer_class = serializers.KpmSerializer
@@ -73,6 +75,7 @@ class ListKpm(generics.ListAPIView):
 class ListBudgetHistory(generics.ListAPIView):
     """
     Historical Operating and Capital Requirements by Service Area and Bureau
+    Note: Parameter values are compared case-insensitive.
     """
     serializer_class = serializers.BudgetHistorySerializer
     filter_class = filters.BudgetHistoryFilter
@@ -170,6 +173,7 @@ class HistorySummaryByServiceAreaObjCode(generics.ListAPIView):
 class ListLookupCode(generics.ListAPIView):
     """
     Code reference table for Budget History.
+    Note: Parameter values are compared case-insensitive.
     """
     serializer_class = serializers.LookupCodeSerializer
     filter_class = filters.LookupCodeFilter

--- a/budget_proj/budget_app/views.py
+++ b/budget_proj/budget_app/views.py
@@ -142,7 +142,7 @@ class HistorySummaryByServiceArea(generics.ListAPIView):
         return Response(serialized_data.data)
 
 
-class HistorySummaryByServiceAreaObjCode(generics.ListAPIView):
+class HistorySummaryByServiceAreaObjectCode(generics.ListAPIView):
     """
     Summary of Historical Operating and Capital Requirements by Service Area and Object Code
     """

--- a/budget_proj/budget_app/views.py
+++ b/budget_proj/budget_app/views.py
@@ -39,13 +39,29 @@ class ListOcrb(generics.ListAPIView):
             # Build a dictionary of query parameters and their values.
             filter_dict = {}
             for key, value in request.GET.items():
-                filter_dict[key.lower() + "__iexact"] = value  # Assumes all model attributes are lowercase.
+                if key != 'page':
+                    filter_dict[key.lower() + "__iexact"] = value  # Assumes all model attributes are lowercase.
             ocrbs = models.OCRB.objects.filter(**filter_dict)
         else:
             ocrbs = self.get_queryset()
         sorted_ocrbs = ocrbs.order_by('fy', 'budget_type', 'service_area', 'bureau', 'budget_category')
+        page = self.paginate_queryset(sorted_ocrbs)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
         serialized_data = self.serializer_class(sorted_ocrbs, many=True)
         return Response(serialized_data.data)
+    #   queryset = self.filter_queryset(self.get_queryset())
+
+        # page = self.paginate_queryset(queryset)
+        # if page is not None:
+        #     serializer = self.get_serializer(page, many=True)
+        #     return self.get_paginated_response(serializer.data)
+
+        # serializer = self.get_serializer(queryset, many=True)
+        # return Response(serializer.data)
+
 
 
 class OcrbSummary(generics.ListAPIView):

--- a/budget_proj/budget_app/views.py
+++ b/budget_proj/budget_app/views.py
@@ -27,7 +27,6 @@ class ListOcrb(generics.ListAPIView):
     serializer_class = serializers.OcrbSerializer
     filter_class = filters.OcrbFilter
 
-
     def get_queryset(self):
         return models.OCRB.objects.order_by('-fy', 'budget_type', 'service_area', 'bureau', 'budget_category')
 
@@ -47,6 +46,7 @@ class OcrbSummary(generics.ListAPIView):
         Uses query parameters to select items to be returned from the database that summarizes Operating and Capital Requirements by Bureau.
         Note: Parameter names and parameter values are compared case-insensitive.
         """
+
         if request.GET.keys():
             # Build a dictionary of query parameters and their values.
             filter_dict = {}
@@ -139,7 +139,7 @@ class HistorySummaryByServiceArea(generics.ListAPIView):
         return Response(serialized_data.data)
 
 
-class HistorySummaryByServiceAreaObjectCode(generics.ListAPIView):
+class HistorySummaryByServiceAreaObjCode(generics.ListAPIView):
     """
     Summary of Historical Operating and Capital Requirements by Service Area and Object Code
     """
@@ -172,21 +172,8 @@ class ListLookupCode(generics.ListAPIView):
     Code reference table for Budget History.
     """
     serializer_class = serializers.LookupCodeSerializer
+    filter_class = filters.LookupCodeFilter
 
 
     def get_queryset(self):
         return models.LookupCode.objects.all()
-
-
-    def get(self, request, *args, **kwargs):
-        if request.GET.keys():
-            # Build a dictionary of query parameters and their values.
-            filter_dict = {}
-            for key, value in request.GET.items():
-                filter_dict[key.lower() + "__iexact"] = value
-            rows = models.LookupCode.objects.filter(**filter_dict)
-        else:
-            rows = self.get_queryset()
-        sorted_rows = rows.order_by('code')
-        serialized_data = self.serializer_class(sorted_rows, many=True)
-        return Response(serialized_data.data)

--- a/budget_proj/budget_proj/settings/base.py
+++ b/budget_proj/budget_proj/settings/base.py
@@ -73,6 +73,13 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'budget_proj.wsgi.application'
 
+
+# DRF Settings:
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 100
+}
+
 # Password validation
 # https://docs.djangoproject.com/en/1.10/ref/settings/#auth-password-validators
 

--- a/budget_proj/budget_proj/settings/base.py
+++ b/budget_proj/budget_proj/settings/base.py
@@ -77,7 +77,8 @@ WSGI_APPLICATION = 'budget_proj.wsgi.application'
 # DRF Settings:
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 100
+    'PAGE_SIZE': 100,
+    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
 }
 
 # Password validation


### PR DESCRIPTION

Defaulting to 100 objects per response.  Can customize as needed for different views.

Here's a snippet of the new response format:

GET http://127.0.0.1:8000/budget/ocrb/

```json
{
    "count": 264,
    "next": "http://127.0.0.1:8000/budget/ocrb/?page=2",
    "previous": null,
    "results": [
        {
            "source_document": "FY 2015-16 Budget in Brief",
            "service_area": "City Support Services",
            "bureau": "City Budget Office",
            "budget_category": "Capital",
            "amount": 238525,
            "fy": "2013-14",
            "budget_type": "Actual"
        },
        {
            "source_document": "FY 2015-16 Budget in Brief",
            "service_area": "City Support Services",
            "bureau": "City Budget Office",
            "budget_category": "Operating",
            "amount": 1578188,
            "fy": "2013-14",
            "budget_type": "Actual"
        },
        {
            "source_document": "FY 2015-16 Budget in Brief",
            "service_area": "City Support Services",
            "bureau": "Fund & Debt Management",
            "budget_category": "Capital",
            "amount": 0,
            "fy": "2013-14",
            "budget_type": "Actual"
        },
        {
            "source_document": "FY 2015-16 Budget in Brief",
            "service_area": "City Support Services",
            "bureau": "Fund & Debt Management",
            "budget_category": "Operating",
            "amount": 514011218,
            "fy": "2013-14",
            "budget_type": "Actual"
        },
        {
            "source_document": "FY 2015-16 Budget in Brief",
            "service_area": "City Support Services",
            "bureau": "Office of Government Relations",
            "budget_category": "Capital",
            "amount": 0,
            "fy": "2013-14",
            "budget_type": "Actual"
        }
]
```
etc.  Note the **count** (total number of rows, not number presented on the page)

 **next** (link to next page) 

**previous** (link to next page if available)

 and **results** (contents, aka the response format we had before pagination)