### PR TITLE
using the recommended number of workers

### DIFF
--- a/budget_proj/bin/docker-entrypoint.sh
+++ b/budget_proj/bin/docker-entrypoint.sh
@@ -7,4 +7,5 @@ echo  Running docker-entrypoint.sh...
 python manage.py collectstatic --no-input
 
 # Fire up a lightweight frontend to host the Django endpoints - gunicorn was the default choice
-gunicorn budget_proj.wsgi:application -b :8000 --keep-alive 60 --worker-class 'gevent' # gevent used to address ELB/gunicorn issue here https://github.com/benoitc/gunicorn/issues/1194
+# gevent used to address ELB/gunicorn issue here https://github.com/benoitc/gunicorn/issues/1194
+gunicorn budget_proj.wsgi:application -b :8000 --keep-alive 60 --worker-class 'gevent' --workers 3


### PR DESCRIPTION
Gunicorn as the web frontend for our Django APIs [recommends](http://docs.gunicorn.org/en/stable/settings.html#workers) > 1 workers depending on the number of CPU cores available.  Each of our API containers in Hack Oregon is allocated a single CPU core, so the recommended advice generally converges on three workers.

I've tested this before and it appears to work just fine.  Plus it sets us up to be able to handle far more concurrent connections when/if these APIs start seeing some real use.