### PR TITLE
Stabilizing the app in AWS - driving out CRITICAL WORKER TIMEOUT issue

### DIFF
--- a/budget_proj/bin/docker-entrypoint.sh
+++ b/budget_proj/bin/docker-entrypoint.sh
@@ -9,4 +9,4 @@ python manage.py collectstatic --no-input
 # Fire up a lightweight frontend to host the Django endpoints - gunicorn was the default choice
 # gevent used to address ELB/gunicorn issue here https://github.com/benoitc/gunicorn/issues/1194
 #gunicorn budget_proj.wsgi:application -b :8000 --keep-alive 60 --worker-class 'gevent' --workers 3
-gunicorn budget_proj.wsgi:application -b :8000 --worker-class 'gevent' --workers 3
+gunicorn budget_proj.wsgi:application -b :8000 --worker-class 'gevent' --workers 1

--- a/budget_proj/bin/docker-entrypoint.sh
+++ b/budget_proj/bin/docker-entrypoint.sh
@@ -8,4 +8,5 @@ python manage.py collectstatic --no-input
 
 # Fire up a lightweight frontend to host the Django endpoints - gunicorn was the default choice
 # gevent used to address ELB/gunicorn issue here https://github.com/benoitc/gunicorn/issues/1194
-gunicorn budget_proj.wsgi:application -b :8000 --keep-alive 60 --worker-class 'gevent' --workers 3
+#gunicorn budget_proj.wsgi:application -b :8000 --keep-alive 60 --worker-class 'gevent' --workers 3
+gunicorn budget_proj.wsgi:application -b :8000 --worker-class 'gevent' --workers 3

--- a/budget_proj/bin/docker-push.sh
+++ b/budget_proj/bin/docker-push.sh
@@ -3,7 +3,7 @@
 # Tag, Push and Deploy only if it's not a pull request
 if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   # Push only if we're testing the master branch
-  if [ "$TRAVIS_BRANCH" == "master" ]; then
+#  if [ "$TRAVIS_BRANCH" == "master" ]; then
     export PATH=$PATH:$HOME/.local/bin
     echo Getting the ECR login... # Troubleshooting
     eval $(aws ecr get-login --region $AWS_DEFAULT_REGION)
@@ -15,9 +15,9 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
      -c "$ECS_CLUSTER"   \
      -i "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest \
      --timeout 300
-   else
-     echo "Skipping deploy because branch is not master"
-  fi
+#   else
+#     echo "Skipping deploy because branch is not master"
+#  fi
 else
   echo "Skipping deploy because it's a pull request"
 fi

--- a/budget_proj/bin/docker-push.sh
+++ b/budget_proj/bin/docker-push.sh
@@ -3,7 +3,7 @@
 # Tag, Push and Deploy only if it's not a pull request
 if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   # Push only if we're testing the master branch
-#  if [ "$TRAVIS_BRANCH" == "master" ]; then
+  if [ "$TRAVIS_BRANCH" == "master" ]; then
     export PATH=$PATH:$HOME/.local/bin
     echo Getting the ECR login... # Troubleshooting
     eval $(aws ecr get-login --region $AWS_DEFAULT_REGION)
@@ -15,9 +15,9 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
      -c "$ECS_CLUSTER"   \
      -i "$DOCKER_REPO"/"$DEPLOY_TARGET"/"$DOCKER_IMAGE":latest \
      --timeout 300
-#   else
-#     echo "Skipping deploy because branch is not master"
-#  fi
+  else
+    echo "Skipping deploy because branch is not master"
+ fi
 else
   echo "Skipping deploy because it's a pull request"
 fi

--- a/budget_proj/budget_proj/wsgi.py
+++ b/budget_proj/budget_proj/wsgi.py
@@ -8,8 +8,11 @@ https://docs.djangoproject.com/en/1.10/howto/deployment/wsgi/
 """
 
 import os
-
 from django.core.wsgi import get_wsgi_application
+from psycogreen.gevent import patch_psycopg
+from gevent import monkey; monkey.patch_all()
+
+patch_psycopg()
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "budget_proj.settings.dev")
 

--- a/budget_proj/requirements/prod.txt
+++ b/budget_proj/requirements/prod.txt
@@ -1,3 +1,4 @@
 -r common.txt
 
-gevent
+gevent==1.2.1
+psycogreen


### PR DESCRIPTION
At today's mini-hack the DevOps squad tackled the slowness and timeouts in all the backend projects.

We were observing numerous, frequent, and repetitive CRITICAL WORKER TIMEOUT errors in the logs for the deployed containers, and noticed these correlated with slow endpoint responses and/or occasional timeouts, 502/504 errors and other issues.

This PR reflects the results of our research that finally extinguished that behaviour.