### PR TITLE
Integrated 'Personnel' plot.

### DIFF
--- a/R/pdx-budget-explorer/DESCRIPTION
+++ b/R/pdx-budget-explorer/DESCRIPTION
@@ -12,12 +12,15 @@ LazyData: TRUE
 Depends:
     R (>= 3.3.3)
 Imports:
-    dplyr (>= 0.5.0),
-    ggplot2 (>= 2.2.1),
+    hrbrthemes (>= 0.1.0),
     httr (>= 1.2.1),
     jsonlite (>= 1.4),
+    lubridate (>= 1.6.0),
     magrittr (>= 1.5),
-    shiny (>= 1.0.2)
+    scales (>= 0.4.1),
+    shiny (>= 1.0.2),
+    stringr (>= 1.2.0),
+    tidyverse (>= 1.1.1)
 Suggests:
     devtools,
     knitr,

--- a/R/pdx-budget-explorer/README.md
+++ b/R/pdx-budget-explorer/README.md
@@ -1,5 +1,5 @@
 # pdx-budget-explorer
-This is a web application for exploring historical budget data for the [City of Portland](https://www.portlandoregon.gov/cbo/), Oregon, USA. This prototype is currently deployed at: [https://jimtyhurst.shinyapps.io/budget-explorer/](https://jimtyhurst.shinyapps.io/budget-explorer/)
+This is a web application for exploring historical budget data for the [City of Portland](https://www.portlandoregon.gov/cbo/), Oregon, USA. This prototype is currently deployed at: [https://hackoregon.shinyapps.io/pdx-budget-explorer/](https://hackoregon.shinyapps.io/pdx-budget-explorer/)
 
 The application is written completely in the [R language](https://www.r-project.org/), using the [Shiny](https://shiny.rstudio.com/) web application framework. Data is pulled from [Hack Oregon](http://www.hackoregon.org/)'s [budget web service](http://service.civicpdx.org/budget/), which is documented [here](https://github.com/hackoregon/team-budget).
 

--- a/R/pdx-budget-explorer/budgetLevels.R
+++ b/R/pdx-budget-explorer/budgetLevels.R
@@ -1,8 +1,0 @@
-
-# Displayable names
-SERVICE_AREA_LEVEL <- "Service Area"
-BUREAU_LEVEL <- "Bureau"
-
-# Field names
-SERVICE_AREA_SELECTOR <- "service_area_code"
-BUREAU_SELECTOR <- "bureau_code"

--- a/R/pdx-budget-explorer/commonConstants.R
+++ b/R/pdx-budget-explorer/commonConstants.R
@@ -1,0 +1,28 @@
+
+# Displayable names
+SERVICE_AREA_LEVEL <- "Service Area"
+BUREAU_LEVEL <- "Bureau"
+
+# Field names
+SERVICE_AREA_SELECTOR <- "service_area_code"
+BUREAU_SELECTOR <- "bureau_code"
+
+# color-blind-friendly palette from http://www.cookbook-r.com/Graphs/Colors_(ggplot2)/
+CBB_PALETTE <-
+  c(
+    BLACK = "#000000",
+    ORANGE = "#E69F00",
+    LIGHT_BLUE = "#56B4E9",
+    GREEN = "#009E73",
+    YELLOW = "#F0E442",
+    BLUE = "#0072B2",
+    RED = "#D55E00",
+    PURPLE = "#CC79A7"
+  )
+
+BUDGET_TEAM_PALETTE <-
+  c(
+    GREEN = "#389E7D"
+  )
+
+SITE_COLOR <- BUDGET_TEAM_PALETTE["GREEN"]

--- a/R/pdx-budget-explorer/data.R
+++ b/R/pdx-budget-explorer/data.R
@@ -13,7 +13,39 @@ ENCODING <- "UTF-8"
 MAX_DOLLARS_PER_YEAR <- data.frame(c(2000000000), c(1500000000))
 colnames(MAX_DOLLARS_PER_YEAR) <- c(SERVICE_AREA_SELECTOR, BUREAU_SELECTOR)
 
-#' Returns data.frame with column names:
+#' Builds the query part of an HTTP call, matching up each field 
+#' with its corresponding value.
+#' 
+#' @param fields array of string field names.
+#' @param values array of string values.
+#' @return string starting with "?", followed by pairs of field
+#' names and values conjoined with "=" and pairs are separated
+#' by "&". For example,
+#' "?fiscal_year=2014-15&object_code=PERSONAL".
+#' Returns empty string when no fields and values are given.
+buildQueryString <- function(fields = c(), values = c()) {
+  query <- ""
+  if (!is.null(fields) && length(fields) > 0 &&
+      !is.null(values) && length(values) > 0) {
+    firstParameter <- TRUE
+    for (i in 1:length(fields)) {
+      if (i <= length(values)) {
+        if (firstParameter) {
+          query <- paste0(query, "?")
+          firstParameter <- FALSE
+        } else {
+          query <- paste0(query, "&")
+        }
+        query <- paste0(query, fields[[i]], "=", values[[i]])
+      }
+    }
+  }
+  return(query)
+}
+
+#' All Budget History columns, filtered by arbitrary choice of
+#' field names and their associated values.
+#' 
 #'   accounting_object_name (name for 'object_code')
 #'   amount
 #'   bureau_code
@@ -31,19 +63,35 @@ colnames(MAX_DOLLARS_PER_YEAR) <- c(SERVICE_AREA_SELECTOR, BUREAU_SELECTOR)
 #'   program_code
 #'   service_area_code
 #'   sub_program_code
-getBudgetHistory <- function(fiscalYear = "2015-16") {
-  return(
-    httr::GET(HISTORY_PATH, query = list(fiscal_year = fiscalYear)) %>%
+#' @param fields array of string field names for filtering.
+#' @param values array of string values for filtering.
+#' @return data.frame with rows that passed the filtering
+#' by field=value pairs. Returns empty data.frame when no rows
+#' pass the filter criteria.
+getBudgetHistory <- function(fields = c(), values = c()) {
+  history <- data.frame()
+  nextPage <- paste0(HISTORY_PATH, buildQueryString(fields = fields, values = values))
+  while (!is.null(nextPage)) {
+    response <-
+      httr::GET(nextPage) %>%
       httr::content(type = "text", encoding = ENCODING) %>%
-      jsonlite::fromJSON() %>%
-      with(results)
-  )
+      jsonlite::fromJSON()
+    nextPage <- response$'next'
+    nextBatch <- response$results
+    history <- rbind(history, nextBatch)
+  }
+  return(history)
 }
 
-#' Returns data.frame with column names:
+#' Aggregates budget amounts by Service Area for a given year.
+#' 
+#' @param fiscalYear string representation must be 4 digits, dash,
+#' 2 digits. For example, "2006-07".
+#' @return data.frame with column names:
 #'   amount
 #'   fiscal_year
 #'   service_area_code
+#' where the amount is aggregated by service_area_code.
 getServiceAreaTotals <- function(fiscalYear = "2015-16") {
   return(
     httr::GET(SERVICE_AREA_PATH, query = list(fiscal_year = fiscalYear)) %>%
@@ -53,12 +101,17 @@ getServiceAreaTotals <- function(fiscalYear = "2015-16") {
   )
 }
 
-#' Returns data.frame with column names:
+#' Aggregates budget amounts by Bureau for a given year.
+#' 
+#' @param fiscalYear string representation must be 4 digits, dash,
+#' 2 digits. For example, "2006-07".
+#' @return data.frame with column names:
 #'   amount
 #'   bureau_code
 #'   bureau_name
 #'   fiscal_year
 #'   service_area_code
+#' where the amount is aggregated by bureau_code.
 getBureauTotals <- function(fiscalYear = "2015-16") {
   return(
     httr::GET(BUREAU_PATH, query = list(fiscal_year = fiscalYear)) %>%

--- a/R/pdx-budget-explorer/data.R
+++ b/R/pdx-budget-explorer/data.R
@@ -13,6 +13,37 @@ ENCODING <- "UTF-8"
 MAX_DOLLARS_PER_YEAR <- data.frame(c(2000000000), c(1500000000))
 colnames(MAX_DOLLARS_PER_YEAR) <- c(SERVICE_AREA_SELECTOR, BUREAU_SELECTOR)
 
+#' Builds the query part of an HTTP call, matching up each field 
+#' with its corresponding value.
+#' 
+#' @param fields array of string field names.
+#' @param values array of string values.
+#' @return string starting with "?", followed by pairs of field
+#' names and values conjoined with "=" and pairs are separated
+#' by "&". For example,
+#' "?fiscal_year=2014-15&object_code=PERSONAL".
+#' Returns empty string when no fields and values are given.
+buildQueryString <- function(fields = c(),
+                             values = c()) {
+  query <- ""
+  if (!is.null(fields) && length(fields) > 0 &&
+      !is.null(values) && length(values) > 0) {
+    firstParameter <- TRUE
+    for (i in 1:length(fields)) {
+      if (i <= length(values)) {
+        if (firstParameter) {
+          query <- paste0(query, "?")
+          firstParameter <- FALSE
+        } else {
+          query <- paste0(query, "&")
+        }
+        query <- paste0(query, fields[[i]], "=", values[[i]])
+      }
+    }
+  }
+  return(query)
+}
+
 #' Returns data.frame with column names:
 #'   accounting_object_name (name for 'object_code')
 #'   amount
@@ -31,13 +62,21 @@ colnames(MAX_DOLLARS_PER_YEAR) <- c(SERVICE_AREA_SELECTOR, BUREAU_SELECTOR)
 #'   program_code
 #'   service_area_code
 #'   sub_program_code
-getBudgetHistory <- function(fiscalYear = "2015-16") {
-  return(
-    httr::GET(HISTORY_PATH, query = list(fiscal_year = fiscalYear)) %>%
+getBudgetHistory <- function(fields = c(), values = c()) {
+  history <- data.frame()
+  nextPage <- paste0(HISTORY_PATH, buildQueryString(fields = fields, values = values))
+  while (!is.null(nextPage)) {
+    cat(paste0(nextPage, "\n"))
+    flush.console()
+    response <- 
+      httr::GET(nextPage) %>%
       httr::content(type = "text", encoding = ENCODING) %>%
-      jsonlite::fromJSON() %>%
-      with(results)
-  )
+      jsonlite::fromJSON()
+    nextPage <- response$'next'
+    nextBatch <- response$results
+    history <- rbind(history, nextBatch)
+  }
+  return(history)
 }
 
 #' Returns data.frame with column names:

--- a/R/pdx-budget-explorer/data.R
+++ b/R/pdx-budget-explorer/data.R
@@ -13,37 +13,6 @@ ENCODING <- "UTF-8"
 MAX_DOLLARS_PER_YEAR <- data.frame(c(2000000000), c(1500000000))
 colnames(MAX_DOLLARS_PER_YEAR) <- c(SERVICE_AREA_SELECTOR, BUREAU_SELECTOR)
 
-#' Builds the query part of an HTTP call, matching up each field 
-#' with its corresponding value.
-#' 
-#' @param fields array of string field names.
-#' @param values array of string values.
-#' @return string starting with "?", followed by pairs of field
-#' names and values conjoined with "=" and pairs are separated
-#' by "&". For example,
-#' "?fiscal_year=2014-15&object_code=PERSONAL".
-#' Returns empty string when no fields and values are given.
-buildQueryString <- function(fields = c(),
-                             values = c()) {
-  query <- ""
-  if (!is.null(fields) && length(fields) > 0 &&
-      !is.null(values) && length(values) > 0) {
-    firstParameter <- TRUE
-    for (i in 1:length(fields)) {
-      if (i <= length(values)) {
-        if (firstParameter) {
-          query <- paste0(query, "?")
-          firstParameter <- FALSE
-        } else {
-          query <- paste0(query, "&")
-        }
-        query <- paste0(query, fields[[i]], "=", values[[i]])
-      }
-    }
-  }
-  return(query)
-}
-
 #' Returns data.frame with column names:
 #'   accounting_object_name (name for 'object_code')
 #'   amount
@@ -62,21 +31,13 @@ buildQueryString <- function(fields = c(),
 #'   program_code
 #'   service_area_code
 #'   sub_program_code
-getBudgetHistory <- function(fields = c(), values = c()) {
-  history <- data.frame()
-  nextPage <- paste0(HISTORY_PATH, buildQueryString(fields = fields, values = values))
-  while (!is.null(nextPage)) {
-    cat(paste0(nextPage, "\n"))
-    flush.console()
-    response <- 
-      httr::GET(nextPage) %>%
+getBudgetHistory <- function(fiscalYear = "2015-16") {
+  return(
+    httr::GET(HISTORY_PATH, query = list(fiscal_year = fiscalYear)) %>%
       httr::content(type = "text", encoding = ENCODING) %>%
-      jsonlite::fromJSON()
-    nextPage <- response$'next'
-    nextBatch <- response$results
-    history <- rbind(history, nextBatch)
-  }
-  return(history)
+      jsonlite::fromJSON() %>%
+      with(results)
+  )
 }
 
 #' Returns data.frame with column names:

--- a/R/pdx-budget-explorer/data.R
+++ b/R/pdx-budget-explorer/data.R
@@ -2,7 +2,7 @@ library(httr)
 library(jsonlite)
 library(magrittr)
 library(dplyr)
-source("budgetLevels.R")
+source("commonConstants.R")
 
 BASE_URL <- "http://service.civicpdx.org/budget"
 HISTORY_PATH <- paste0(BASE_URL, "/history")

--- a/R/pdx-budget-explorer/server.R
+++ b/R/pdx-budget-explorer/server.R
@@ -1,45 +1,29 @@
 library(shiny)
-library(stringr)
-library(tidyverse)
-library(lubridate)
-library(tidyr)
-library(hrbrthemes)
-library(scales)
-
+library(ggplot2)
 source("budgetLevels.R")
 source("data.R")
 
-BUDGET_PLOT_TITLE <- "Budget for the City of Portland"
-
-# color-blind-friendly palette from http://www.cookbook-r.com/Graphs/Colors_(ggplot2)/
-CBB_PALETTE <-
-  c(
-    BLACK = "#000000",
-    ORANGE = "#E69F00",
-    LIGHT_BLUE = "#56B4E9",
-    GREEN = "#009E73",
-    YELLOW = "#F0E442",
-    BLUE = "#0072B2",
-    RED = "#D55E00",
-    PURPLE = "#CC79A7"
-  )
-
-# Translates budgetLevel selection to displayable name.
-BUDGET_LEVEL_NAMES <- list(SERVICE_AREA_LEVEL, BUREAU_LEVEL)
-names(BUDGET_LEVEL_NAMES) <- c(SERVICE_AREA_SELECTOR, BUREAU_SELECTOR)
-
-# Plot variables against total budget.
+# Server logic required to plot variables against total budget.
 shinyServer(function(input, output) {
+  BUDGET_PLOT_TITLE <- "Budget for the City of Portland"
+
+  # color-blind-friendly palette from http://www.cookbook-r.com/Graphs/Colors_(ggplot2)/
+  cbbPalette <- c(BLACK = "#000000", ORANGE = "#E69F00", LIGHT_BLUE = "#56B4E9", GREEN = "#009E73", YELLOW = "#F0E442", BLUE = "#0072B2", RED = "#D55E00", PURPLE = "#CC79A7")
+
+  # Translates budgetLevel selection to displayable name.
+  budgetLevelNameMap <- list(SERVICE_AREA_LEVEL, BUREAU_LEVEL)
+  names(budgetLevelNameMap) <- c(SERVICE_AREA_SELECTOR, BUREAU_SELECTOR)
+
   # Computes the caption in a reactive expression, because
   # it depends on the choices of budgetLevel and fiscalYear.
   captionText <- reactive({
-    paste("By", BUDGET_LEVEL_NAMES[[input$budgetLevel]], "for", input$fiscalYear)
+    paste("By", budgetLevelNameMap[[input$budgetLevel]], "for", input$fiscalYear)
   })
-  
+
   budgetLevelName <- reactive({
-    BUDGET_LEVEL_NAMES[[input$budgetLevel]]
+    budgetLevelNameMap[[input$budgetLevel]]
   })
-  
+
   ####################
   output$budgetPlot <- renderPlot({
     if (SERVICE_AREA_SELECTOR == input$budgetLevel) {
@@ -47,8 +31,8 @@ shinyServer(function(input, output) {
       ggplot(data = budgetData,
              aes(x = reorder(service_area_code, amount), y = amount)) +
         geom_bar(stat = "identity",
-                 fill = CBB_PALETTE["LIGHT_BLUE"],
-                 colour = CBB_PALETTE["LIGHT_BLUE"]) +
+                 fill = cbbPalette["LIGHT_BLUE"],
+                 colour = cbbPalette["LIGHT_BLUE"]) +
         scale_y_continuous(limits = getAmountLimits(SERVICE_AREA_SELECTOR)) +
         coord_flip() +
         xlab(budgetLevelName()) +
@@ -59,8 +43,8 @@ shinyServer(function(input, output) {
       ggplot(data = budgetData,
              aes(x = reorder(bureau_code, amount), y = amount)) +
         geom_bar(stat = "identity",
-                 fill = CBB_PALETTE["LIGHT_BLUE"],
-                 colour = CBB_PALETTE["LIGHT_BLUE"]) +
+                 fill = cbbPalette["LIGHT_BLUE"],
+                 colour = cbbPalette["LIGHT_BLUE"]) +
         scale_y_continuous(limits = getAmountLimits(BUREAU_SELECTOR)) +
         coord_flip() +
         xlab(budgetLevelName()) +
@@ -68,25 +52,5 @@ shinyServer(function(input, output) {
         ggtitle(paste0(BUDGET_PLOT_TITLE, ": ", captionText()))
     }
   })
-  
-  output$personnelPlot <- renderPlot({
-    getBudgetHistory(fields = c("object_code"), values = c("PERSONAL")) %>% 
-      mutate(
-        amount = amount / 1000000
-      ) %>% 
-      ggplot(aes(fiscal_year, amount)) +
-      scale_y_continuous(labels = comma) +
-      geom_bar(stat = "identity") +
-      #coord_flip() +
-      facet_wrap(~bureau_name) +
-      labs(x = "Fiscal\nYear", y = "Millions of Dollars",
-           title = "Personnel Budget by Bureau and Fiscal-Year"
-      ) +
-      theme_ipsum()
-  })
-  
-  output$enterprisePlot <- renderText({
-    "FIXME: Use renderPlot Enterprise Fund data here."
-  })
-  
+
 })

--- a/R/pdx-budget-explorer/server.R
+++ b/R/pdx-budget-explorer/server.R
@@ -5,23 +5,10 @@ library(lubridate)
 library(tidyr)
 library(hrbrthemes)
 library(scales)
-source("budgetLevels.R")
+source("commonConstants.R")
 source("data.R")
 
 BUDGET_PLOT_TITLE <- "Budget for the City of Portland"
-
-# color-blind-friendly palette from http://www.cookbook-r.com/Graphs/Colors_(ggplot2)/
-CBB_PALETTE <-
-  c(
-    BLACK = "#000000",
-    ORANGE = "#E69F00",
-    LIGHT_BLUE = "#56B4E9",
-    GREEN = "#009E73",
-    YELLOW = "#F0E442",
-    BLUE = "#0072B2",
-    RED = "#D55E00",
-    PURPLE = "#CC79A7"
-  )
 
 # Translates budgetLevel selection to displayable name.
 BUDGET_LEVEL_NAMES <- list(SERVICE_AREA_LEVEL, BUREAU_LEVEL)
@@ -45,8 +32,8 @@ shinyServer(function(input, output) {
       ggplot(data = budgetData,
              aes(x = reorder(service_area_code, amount), y = amount)) +
         geom_bar(stat = "identity",
-                 fill = CBB_PALETTE["LIGHT_BLUE"],
-                 colour = CBB_PALETTE["LIGHT_BLUE"]) +
+                 fill = SITE_COLOR,
+                 colour = SITE_COLOR) +
         scale_y_continuous(limits = getAmountLimits(SERVICE_AREA_SELECTOR)) +
         coord_flip() +
         xlab(budgetLevelName()) +
@@ -57,8 +44,8 @@ shinyServer(function(input, output) {
       ggplot(data = budgetData,
              aes(x = reorder(bureau_code, amount), y = amount)) +
         geom_bar(stat = "identity",
-                 fill = CBB_PALETTE["LIGHT_BLUE"],
-                 colour = CBB_PALETTE["LIGHT_BLUE"]) +
+                 fill = SITE_COLOR,
+                 colour = SITE_COLOR) +
         scale_y_continuous(limits = getAmountLimits(BUREAU_SELECTOR)) +
         coord_flip() +
         xlab(budgetLevelName()) +
@@ -72,10 +59,12 @@ shinyServer(function(input, output) {
       mutate(amount = amount / 1000000) %>%
       ggplot(aes(fiscal_year, amount)) +
       scale_y_continuous(labels = comma) +
-      geom_bar(stat = "identity") +
+      geom_bar(stat = "identity",
+               fill = SITE_COLOR,
+               colour = SITE_COLOR) +
       #coord_flip() +
-      facet_wrap( ~ bureau_name) +
-      labs(x = "Fiscal\nYear", 
+      facet_wrap(~ bureau_name) +
+      labs(x = "Fiscal\nYear",
            y = "Millions of Dollars",
            title = "Personnel Budget by Bureau and Fiscal-Year") +
       theme_ipsum()

--- a/R/pdx-budget-explorer/server.R
+++ b/R/pdx-budget-explorer/server.R
@@ -1,5 +1,11 @@
 library(shiny)
-library(ggplot2)
+library(stringr)
+library(tidyverse)
+library(lubridate)
+library(tidyr)
+library(hrbrthemes)
+library(scales)
+
 source("budgetLevels.R")
 source("data.R")
 
@@ -63,8 +69,20 @@ shinyServer(function(input, output) {
     }
   })
   
-  output$personnelPlot <- renderText({
-    "FIXME: Use renderPlot Personnel data here."
+  output$personnelPlot <- renderPlot({
+    getBudgetHistory(fields = c("object_code"), values = c("PERSONAL")) %>% 
+      mutate(
+        amount = amount / 1000000
+      ) %>% 
+      ggplot(aes(fiscal_year, amount)) +
+      scale_y_continuous(labels = comma) +
+      geom_bar(stat = "identity") +
+      #coord_flip() +
+      facet_wrap(~bureau_name) +
+      labs(x = "Fiscal\nYear", y = "Millions of Dollars",
+           title = "Personnel Budget by Bureau and Fiscal-Year"
+      ) +
+      theme_ipsum()
   })
   
   output$enterprisePlot <- renderText({

--- a/R/pdx-budget-explorer/ui.R
+++ b/R/pdx-budget-explorer/ui.R
@@ -7,39 +7,27 @@ names(BUDGET_LEVEL_SELECTIONS) <- list(SERVICE_AREA_LEVEL, BUREAU_LEVEL)
 # Displays budget data for the City of Portland.
 shinyUI(fluidPage(
   titlePanel("PDX Budget Explorer"),
-  p(h4(em("Prototype ... work in progress!"))),
-  tabsetPanel(
-    tabPanel("Service/Bureau",
-             sidebarLayout(
-               # Controls to select the level of the budget to be plotted.
-               sidebarPanel(
-                 selectInput("budgetLevel", "Level:", BUDGET_LEVEL_SELECTIONS),
-                 selectInput(
-                   "fiscalYear",
-                   "Fiscal Year:",
-                   list(
-                     "2015-16" = "2015-16",
-                     "2014-15" = "2014-15",
-                     "2013-14" = "2013-14",
-                     "2012-13" = "2012-13",
-                     "2011-12" = "2011-12",
-                     "2010-11" = "2010-11",
-                     "2009-10" = "2009-10",
-                     "2008-09" = "2008-09",
-                     "2007-08" = "2007-08",
-                     "2006-07" = "2006-07"
-                   )
-                 )
-               ),
-               
-               # Shows the caption and plot of the requested variable.
-               mainPanel(plotOutput("budgetPlot"))
-             )),
-    
-    tabPanel("Personnel",
-             plotOutput("personnelPlot")),
-    
-    tabPanel("Enterprise Fund",
-             textOutput("enterprisePlot")) # FIXME: Use plotOutput)
+  sidebarLayout(
+    # Controls to select the level of the budget to be plotted.
+    sidebarPanel(
+      p(h4(em("Prototype only!"))),
+      selectInput("budgetLevel", "Level:", BUDGET_LEVEL_SELECTIONS),
+      selectInput("fiscalYear", "Fiscal Year:",
+                  list("2015-16" = "2015-16",
+                       "2014-15" = "2014-15",
+                       "2013-14" = "2013-14",
+                       "2012-13" = "2012-13",
+                       "2011-12" = "2011-12",
+                       "2010-11" = "2010-11",
+                       "2009-10" = "2009-10",
+                       "2008-09" = "2008-09",
+                       "2007-08" = "2007-08",
+                       "2006-07" = "2006-07"))
+    ),
+
+    # Shows the caption and plot of the requested variable.
+    mainPanel(
+      plotOutput("budgetPlot")
+    )
   )
 ))

--- a/R/pdx-budget-explorer/ui.R
+++ b/R/pdx-budget-explorer/ui.R
@@ -1,33 +1,47 @@
 library(shiny)
 source("budgetLevels.R")
 
-BUDGET_LEVEL_SELECTIONS <- list(SERVICE_AREA_SELECTOR, BUREAU_SELECTOR)
-names(BUDGET_LEVEL_SELECTIONS) <- list(SERVICE_AREA_LEVEL, BUREAU_LEVEL)
+BUDGET_LEVEL_SELECTIONS <-
+  list(SERVICE_AREA_SELECTOR, BUREAU_SELECTOR)
+names(BUDGET_LEVEL_SELECTIONS) <-
+  list(SERVICE_AREA_LEVEL, BUREAU_LEVEL)
 
 # Displays budget data for the City of Portland.
 shinyUI(fluidPage(
   titlePanel("PDX Budget Explorer"),
-  sidebarLayout(
-    # Controls to select the level of the budget to be plotted.
-    sidebarPanel(
-      p(h4(em("Prototype only!"))),
-      selectInput("budgetLevel", "Level:", BUDGET_LEVEL_SELECTIONS),
-      selectInput("fiscalYear", "Fiscal Year:",
-                  list("2015-16" = "2015-16",
-                       "2014-15" = "2014-15",
-                       "2013-14" = "2013-14",
-                       "2012-13" = "2012-13",
-                       "2011-12" = "2011-12",
-                       "2010-11" = "2010-11",
-                       "2009-10" = "2009-10",
-                       "2008-09" = "2008-09",
-                       "2007-08" = "2007-08",
-                       "2006-07" = "2006-07"))
-    ),
+  p(h4(em("Prototype ... work in progress!"))),
+  tabsetPanel(
+    tabPanel("Service/Bureau",
+             sidebarLayout(
+               # Controls to select the level of the budget to be plotted.
+               sidebarPanel(
+                 selectInput("budgetLevel", "Level:", BUDGET_LEVEL_SELECTIONS),
+                 selectInput(
+                   "fiscalYear",
+                   "Fiscal Year:",
+                   list(
+                     "2015-16" = "2015-16",
+                     "2014-15" = "2014-15",
+                     "2013-14" = "2013-14",
+                     "2012-13" = "2012-13",
+                     "2011-12" = "2011-12",
+                     "2010-11" = "2010-11",
+                     "2009-10" = "2009-10",
+                     "2008-09" = "2008-09",
+                     "2007-08" = "2007-08",
+                     "2006-07" = "2006-07"
+                   )
+                 )
+               ),
+               
+               # Shows the caption and plot of the requested variable.
+               mainPanel(plotOutput("budgetPlot"))
+             )),
+    
+    tabPanel("Personnel",
+             plotOutput("personnelPlot")),
 
-    # Shows the caption and plot of the requested variable.
-    mainPanel(
-      plotOutput("budgetPlot")
-    )
+    tabPanel("Enterprise Fund",
+             textOutput("enterprisePlot")) # FIXME: Use plotOutput)
   )
 ))

--- a/R/pdx-budget-explorer/ui.R
+++ b/R/pdx-budget-explorer/ui.R
@@ -37,7 +37,7 @@ shinyUI(fluidPage(
              )),
     
     tabPanel("Personnel",
-             textOutput("personnelPlot")), # FIXME: Use plotOutput
+             plotOutput("personnelPlot")),
     
     tabPanel("Enterprise Fund",
              textOutput("enterprisePlot")) # FIXME: Use plotOutput)

--- a/R/pdx-budget-explorer/ui.R
+++ b/R/pdx-budget-explorer/ui.R
@@ -1,5 +1,5 @@
 library(shiny)
-source("budgetLevels.R")
+source("commonConstants.R")
 
 BUDGET_LEVEL_SELECTIONS <-
   list(SERVICE_AREA_SELECTOR, BUREAU_SELECTOR)
@@ -10,6 +10,7 @@ names(BUDGET_LEVEL_SELECTIONS) <-
 shinyUI(fluidPage(
   titlePanel("PDX Budget Explorer"),
   p(h4(em("Prototype ... work in progress!"))),
+  
   tabsetPanel(
     tabPanel("Service/Bureau",
              sidebarLayout(
@@ -38,10 +39,13 @@ shinyUI(fluidPage(
                mainPanel(plotOutput("budgetPlot"))
              )),
     
-    tabPanel("Personnel",
-             plotOutput("personnelPlot")),
-
-    tabPanel("Enterprise Fund",
-             textOutput("enterprisePlot")) # FIXME: Use plotOutput)
+    tabPanel("Personnel", plotOutput("personnelPlot")),
+    
+    tabPanel("Enterprise Fund", textOutput("enterprisePlot")),
+    
+    tags$head(tags$style(
+      type = "text/css",
+      paste0("li a{color: ", SITE_COLOR, ";}")
+    ))
   )
 ))

--- a/budget_proj/budget_proj/settings/base.py
+++ b/budget_proj/budget_proj/settings/base.py
@@ -79,7 +79,7 @@ WSGI_APPLICATION = 'budget_proj.wsgi.application'
 # DRF Settings:
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 1000,
+    'PAGE_SIZE': 100,
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
 }
 

--- a/budget_proj/budget_proj/settings/base.py
+++ b/budget_proj/budget_proj/settings/base.py
@@ -79,7 +79,7 @@ WSGI_APPLICATION = 'budget_proj.wsgi.application'
 # DRF Settings:
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 100,
+    'PAGE_SIZE': 1000,
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
 }
 


### PR DESCRIPTION
* The Shiny-based web application now has tabs.
* I used @smithjd 's code to create a 'Personnel' tab in the R code. The set of tables display very small, so they do not look as good as when running from his [Rmarkdown script](https://github.com/smithjd/hack_or_budget/blob/master/graphs-1.Rmd). We need to fix that, but I will still merge these changes, because it is at least a step forward. The display panel probably needs to be sized.
* The data layer can now handle the paging from the web service at least for the general /history endpoint. We need to change the size of pages though. It takes a **long** time for the 'Personnel' tab to display, because the app has to access 228 pages from the web service.
* Cleaned up some of the constants.