### PR TITLE
Reduced page size from 1000 to 680 to avoid 'Gateway' errors.

### DIFF
--- a/budget_proj/budget_proj/settings/base.py
+++ b/budget_proj/budget_proj/settings/base.py
@@ -79,7 +79,7 @@ WSGI_APPLICATION = 'budget_proj.wsgi.application'
 # DRF Settings:
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 1000,
+    'PAGE_SIZE': 680,
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
 }
 


### PR DESCRIPTION
* Still experimenting. Page size 1000 led to 504 Gateway error in one call, although another call completed.
* This commit tries a smaller page size of 680 rows in web service response.
