### PR TITLE
Changed variable from 'service_area_code' to 'sa_calced'

### DIFF
--- a/R/pdx-budget-explorer/R/commonConstants.R
+++ b/R/pdx-budget-explorer/R/commonConstants.R
@@ -4,7 +4,7 @@ SERVICE_AREA_LEVEL <- "Service Area"
 BUREAU_LEVEL <- "Bureau"
 
 # Field names
-SERVICE_AREA_SELECTOR <- "service_area_code"
+SERVICE_AREA_SELECTOR <- "sa_calced"
 BUREAU_SELECTOR <- "bureau_code"
 
 # color-blind-friendly palette from http://www.cookbook-r.com/Graphs/Colors_(ggplot2)/

--- a/R/pdx-budget-explorer/server.R
+++ b/R/pdx-budget-explorer/server.R
@@ -32,7 +32,7 @@ shinyServer(function(input, output) {
     if (SERVICE_AREA_SELECTOR == input$budgetLevel) {
       budgetData <- getServiceAreaTotals(input$fiscalYear)
       ggplot(data = budgetData,
-             aes(x = reorder(service_area_code, amount), y = amount)) +
+             aes(x = reorder(sa_calced, amount), y = amount)) +
         geom_bar(stat = "identity",
                  fill = SITE_COLOR,
                  colour = SITE_COLOR) +
@@ -138,8 +138,8 @@ shinyServer(function(input, output) {
           aes(
             x = fiscal_year,
             y = amount,
-            group = service_area_code,
-            colour = service_area_code
+            group = sa_calced,
+            colour = sa_calced
           )
         ) +
         geom_line(stat = "identity") +


### PR DESCRIPTION
Pull Request #146 changed variable name returned by web service using `HistorySummaryByServiceAreaSerializer` from `service_area_code` to `sa_calced`. This pull request integrates the R web application with that change. The `Service Areas by Fiscal Year` plot now shows all 7 Service Areas, rather than just 6.