### PR TITLE
Fixed label on 'Service Area by Fiscal Year' plot. 

### DIFF
--- a/R/pdx-budget-explorer/R/commonConstants.R
+++ b/R/pdx-budget-explorer/R/commonConstants.R
@@ -4,7 +4,7 @@ SERVICE_AREA_LEVEL <- "Service Area"
 BUREAU_LEVEL <- "Bureau"
 
 # Field names
-SERVICE_AREA_SELECTOR <- "sa_calced"
+SERVICE_AREA_SELECTOR <- "service_area_code"
 BUREAU_SELECTOR <- "bureau_code"
 
 # color-blind-friendly palette from http://www.cookbook-r.com/Graphs/Colors_(ggplot2)/

--- a/R/pdx-budget-explorer/R/data.R
+++ b/R/pdx-budget-explorer/R/data.R
@@ -113,8 +113,14 @@ getServiceAreaTotals <- function(fiscalYear = "2015-16") {
     httr::GET(SERVICE_AREA_PATH, query = list(fiscal_year = fiscalYear)) %>%
       httr::content(type = "text", encoding = ENCODING) %>%
       jsonlite::fromJSON() %>%
-      with(results)
+      with(results) %>%
+      standardizeColNames()
   )
+}
+
+standardizeColNames <- function(df) {
+  colnames(df)[colnames(df) == "sa_calced"] <- SERVICE_AREA_SELECTOR
+  return(df)
 }
 
 #' Aggregates budget amounts by Service Area for all years.
@@ -142,6 +148,7 @@ getAllServiceAreaTotals <- function(progressCallback = NULL) {
       )
     }
   }
+  history <- standardizeColNames(history)
   return(history)
 }
 

--- a/R/pdx-budget-explorer/server.R
+++ b/R/pdx-budget-explorer/server.R
@@ -135,11 +135,11 @@ shinyServer(function(input, output) {
       getAllServiceAreaTotals(progressCallback = shiny::setProgress) %>%
         dplyr::mutate(amount = amount / 1000000) %>%
         ggplot(
-          aes(
-            x = fiscal_year,
-            y = amount,
-            group = service_area_code,
-            colour = service_area_code
+          aes_string(
+            x = 'fiscal_year',
+            y = 'amount',
+            group = SERVICE_AREA_SELECTOR,
+            colour = SERVICE_AREA_SELECTOR
           )
         ) +
         geom_line(stat = "identity") +

--- a/R/pdx-budget-explorer/server.R
+++ b/R/pdx-budget-explorer/server.R
@@ -32,7 +32,7 @@ shinyServer(function(input, output) {
     if (SERVICE_AREA_SELECTOR == input$budgetLevel) {
       budgetData <- getServiceAreaTotals(input$fiscalYear)
       ggplot(data = budgetData,
-             aes(x = reorder(sa_calced, amount), y = amount)) +
+             aes(x = reorder(service_area_code, amount), y = amount)) +
         geom_bar(stat = "identity",
                  fill = SITE_COLOR,
                  colour = SITE_COLOR) +
@@ -138,14 +138,16 @@ shinyServer(function(input, output) {
           aes(
             x = fiscal_year,
             y = amount,
-            group = sa_calced,
-            colour = sa_calced
+            group = service_area_code,
+            colour = service_area_code
           )
         ) +
         geom_line(stat = "identity") +
         scale_y_continuous(labels = comma) +
         labs(x = "Fiscal\nYear", y = "Millions of Dollars",
              title = "Service Areas by Fiscal Year") +
+        scale_shape_discrete(name = "Service Area") + 
+        scale_colour_discrete(name = "Service Area") +
         hrbrthemes::theme_ipsum()
     },
     value = 0,


### PR DESCRIPTION
Transforms new 'sa_calced' column into 'service_area_code' in the data layer. Then the rest of the code can assume the canonical 'service_area_code'.