### PR TITLE
Added 'EO' code to service_area_code types.

### DIFF
--- a/Data/lookupcode.csv
+++ b/Data/lookupcode.csv
@@ -1638,3 +1638,4 @@
 6894,"division_code","WAOP","Operations"
 6895,"division_code","WARP","Resource Protection & Planning"
 6896,"division_code","ZDFS","Portland Development Commission Grant Management"
+6897,"service_area_code","EO","Elected Officials"

--- a/budget_proj/budget_app/migrations/0005_auto_20170418_0251.py
+++ b/budget_proj/budget_app/migrations/0005_auto_20170418_0251.py
@@ -70,7 +70,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='budgethistory',
             name='service_area_code',
-            field=models.CharField(default='', help_text='2-character ID [CD, LA, PR, PS, PU, TP] for a Service Area, which is a grouping of related Bureaus.', max_length=32),
+            field=models.CharField(default='', help_text='2-character ID [CD, EO, LA, PR, PS, PU, TP] for a Service Area, which is a grouping of related Bureaus.', max_length=32),
         ),
         migrations.AlterField(
             model_name='kpm',

--- a/budget_proj/budget_app/migrations/0006_index_and_alphabetize.py
+++ b/budget_proj/budget_app/migrations/0006_index_and_alphabetize.py
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='budgethistory',
             name='service_area_code',
-            field=models.CharField(db_index=True, default='', help_text='2-character ID [CD, LA, PR, PS, PU, TP] for a Service Area, which is a grouping of related Bureaus.', max_length=32),
+            field=models.CharField(db_index=True, default='', help_text='2-character ID [CD, EO, LA, PR, PS, PU, TP] for a Service Area, which is a grouping of related Bureaus.', max_length=32),
         ),
         migrations.AlterField(
             model_name='kpm',

--- a/budget_proj/budget_app/models.py
+++ b/budget_proj/budget_app/models.py
@@ -66,5 +66,5 @@ class BudgetHistory(models.Model):
     object_code.help_text = 'Short string ID for a general accounting category, e.g. "EMS" for External Material and Services or "CAPITAL" for Capital Expenditures.'
     program_code = models.CharField(max_length=32, default='')
     service_area_code = models.CharField(db_index=True, max_length=32, default='')
-    service_area_code.help_text = '2-character ID [CD, LA, PR, PS, PU, TP] for a Service Area, which is a grouping of related Bureaus.'
+    service_area_code.help_text = '2-character ID [CD, EO, LA, PR, PS, PU, TP] for a Service Area, which is a grouping of related Bureaus.'
     sub_program_code = models.CharField(max_length=32, default='')

--- a/sql/lookupcode.sql
+++ b/sql/lookupcode.sql
@@ -63,6 +63,8 @@ insert into public.budget_app_lookupcode (code_type, code, description) select '
 insert into public.budget_app_lookupcode (code_type, code, description) select 'bureau_code',bureau_code, bureau_name from public.budget_app_budgethistory group by bureau_code,bureau_name;
 insert into public.budget_app_lookupcode (code_type, code, description) select 'fund_center_code',fund_center_code, fund_center_name from public.budget_app_budgethistory group by fund_center_code,fund_center_name;
 insert into public.budget_app_lookupcode (code_type, code, description) select 'functional_area_code',functional_area_code, functional_area_name from public.budget_app_budgethistory group by functional_area_code,functional_area_name;
+-- add rows that cannot be derived from public.budget_app_budgethistory
+insert into public.budget_app_lookupcode (code_type, code, description) values ('service_area_code', 'EO', 'Elected Officials');
 end
 
 

--- a/sql/lookupcode_sqlite.sql
+++ b/sql/lookupcode_sqlite.sql
@@ -22,6 +22,9 @@ insert into main.budget_app_lookupcode (code_type, code, description) select 'bu
 insert into main.budget_app_lookupcode (code_type, code, description) select 'fund_center_code',fund_center_code, fund_center_name from main.budget_app_budgethistory group by fund_center_code,fund_center_name;
 insert into main.budget_app_lookupcode (code_type, code, description) select 'functional_area_code',functional_area_code, functional_area_name from main.budget_app_budgethistory group by functional_area_code,functional_area_name;
 
+-- add rows that cannot be derived from main.budget_app_budgethistory
+insert into main.budget_app_lookupcode (code_type, code, description) values ('service_area_code', 'EO', 'Elected Officials');
+
 
 -- update service areas with description from spreadsheet
 update main.budget_app_lookupcode set description='Community Development' where code='CD' and code_type='service_area_code';


### PR DESCRIPTION
'EO'='Elected Officials' is a derived Service Area (see Pull Request #146), so it does not appear in the original extract of budget history data that we received (https://github.com/hackoregon/team-budget/blob/master/Data/HackOregon_hx_budget_data_ASV2_extracted.csv). At some point, when we have a pipeline for data from the City to Hack Oregon, we should worry about how this value gets defined. For now, I just inserted it manually into the CSV file, so that it can be loaded into the budget database. This value enables a client to translate the 'EO' value from a service_area_code or sa_calced field in a /budget/history/service_area response into a displayable string for presentation on a UI.